### PR TITLE
Displayed addons in tree view. Added polling for dyno restarts.

### DIFF
--- a/src/extension/commands/dyno/restart.dyno.spec.ts
+++ b/src/extension/commands/dyno/restart.dyno.spec.ts
@@ -70,13 +70,17 @@ suite('The RestartDynoCommand', () => {
   });
 
   test('restarts the dyno', async () => {
-    fetchStub.callsFake(async () => {
-      return new Response('{}');
+    fetchStub.onFirstCall().callsFake(async () => {
+      return new Response(JSON.stringify({id: '1234', state: 'starting'} as Dyno));
+    });
+
+    fetchStub.onSecondCall().callsFake(async () => {
+      return new Response(JSON.stringify({ id: '1234', state: 'up' } as Dyno));
     });
 
     await vscode.commands.executeCommand<string>(RestartDynoCommand.COMMAND_ID, dyno);
     assert.ok(!!getSessionStub.exceptions.length);
-    assert.ok(setStatusBarMessageStub.calledWith(`${dyno.name} is restarting...`));
+    assert.ok(setStatusBarMessageStub.calledWith('tester-dyno is up'));
   });
 
   test('shows appropriate status message when restarting fails', async () => {

--- a/src/extension/commands/dyno/stop-dyno.ts
+++ b/src/extension/commands/dyno/stop-dyno.ts
@@ -18,7 +18,7 @@ export class StopDynoCommand extends AbortController implements RunnableCommand<
    * @returns void
    */
   public async run(dyno: Dyno): Promise<void> {
-    const confirmation = await vscode.window.showWarningMessage(`This action will scae the ${dyno.name} dyno to zero.`, {modal: true}, 'Cancel', 'Stop Dyno');
+    const confirmation = await vscode.window.showWarningMessage(`This action will scale the ${dyno.name} dyno to zero.`, {modal: true}, 'Stop Dyno');
     if (confirmation !== 'Stop Dyno') {
       return;
     }


### PR DESCRIPTION
This PR adds AddOns to the tree view with icons matching the branding, displays the options for SETTINGS and adds polling when the user restarts a Dyno.

## To Test
1. Checkout this branch, install and run the extension.
2. Open a Heroku project source code in the VSCode instance that opens with the extension running.
3. Make sure at least one add-on is installed and that you have deployed the sources to a Heroku app.
4. Observe the AddOns section. 