### PR TITLE
fix: duplicate log output windows are shown for log streams

### DIFF
--- a/src/extension/meta/command.ts
+++ b/src/extension/meta/command.ts
@@ -42,11 +42,12 @@ export function getOutputChannel(config?: CommandDecoratorConfig | undefined): v
     return;
   }
   const { outputChannelId, languageId } = config;
-  let outputChannel = commandOutputChannels.get(`${outputChannelId}${languageId ?? ''}`);
+  const key = `${outputChannelId}${languageId ?? ''}`;
+  let outputChannel = commandOutputChannels.get(key);
   if (!outputChannel) {
     outputChannel = commandOutputChannels
-      .set(outputChannelId, vscode.window.createOutputChannel(outputChannelId, languageId))
-      .get(outputChannelId);
+      .set(key, vscode.window.createOutputChannel(outputChannelId, languageId))
+      .get(key);
   }
   return outputChannel as vscode.OutputChannel;
 }


### PR DESCRIPTION
fix: duplicate log output windows are shown for log streams

before:
<img width="194" alt="image" src="https://github.com/user-attachments/assets/13464ae4-2052-424c-a28f-b7eb775aad14" />

after:
<img width="199" alt="image" src="https://github.com/user-attachments/assets/6c1f1fcb-9154-40fe-bec3-5ecb7bdea822" />
