### PR TITLE
Fixes a condition where ignored files could be included when deploying

### DIFF
--- a/src/extension/utils/tarball.ts
+++ b/src/extension/utils/tarball.ts
@@ -1,7 +1,10 @@
 import zlib from 'node:zlib';
+import { readFile, stat, readdir } from 'node:fs/promises';
+import path from 'node:path';
 import vscode from 'vscode';
 import * as tar from 'tar-stream';
 import { HerokuCommand } from '../commands/heroku-command';
+import { logExtensionEvent } from './logger';
 
 /**
  * Creates a compressed tarball (tar.gz) from the contents of a workspace folder.
@@ -25,22 +28,7 @@ import { HerokuCommand } from '../commands/heroku-command';
  * @throws {Error} If unable to read workspace files or create the tarball
  */
 export async function packSources(root: vscode.Uri, signal?: AbortSignal): Promise<Uint8Array> {
-  const include = new vscode.RelativePattern(root, '**/*');
-  const exclude = new vscode.RelativePattern(root, '**/node_modules/**');
-
-  const files = await vscode.workspace.findFiles(include, exclude);
-  const gitProcess = HerokuCommand.exec('git check-ignore --no-index --stdin', { cwd: root.fsPath, signal });
-  gitProcess.stdin?.write(files.map((file) => file.fsPath).join('\n'));
-  gitProcess.stdin?.end();
-  const result = await HerokuCommand.waitForCompletion(gitProcess);
-  const ignored = result.output
-    .toString()
-    .split('\n')
-    .filter(Boolean)
-    .reduce((set, path) => {
-      set.add(path);
-      return set;
-    }, new Set());
+  const files = await getSourceFilePaths(root, signal);
 
   const pack = tar.pack();
   const gzip = zlib.createGzip();
@@ -51,10 +39,7 @@ export async function packSources(root: vscode.Uri, signal?: AbortSignal): Promi
   pack.pipe(gzip);
 
   for (const file of files) {
-    if (ignored?.has(file.fsPath)) {
-      continue;
-    }
-    const content = await vscode.workspace.fs.readFile(file);
+    const content = await readFile(file);
     const relativePath = vscode.workspace.asRelativePath(file, false);
     pack.entry({ name: relativePath }, Buffer.from(content));
   }
@@ -62,4 +47,74 @@ export async function packSources(root: vscode.Uri, signal?: AbortSignal): Promi
   pack.finalize();
   await new Promise((resolve) => gzip.on('end', resolve));
   return Buffer.concat(chunks);
+}
+
+/**
+ * Gets the source files within the provided git repo
+ *
+ * @param root The root directory of the git repo to get files for
+ * @param signal The abort signal to cancel the operation
+ * @returns A list of file paths to be included in the tarball
+ *
+ * @example
+ * const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+ */
+export async function getSourceFilePaths(root: vscode.Uri, signal?: AbortSignal): Promise<string[]> {
+  // git command to list all tracked files and directories
+  // that do not match the patterns in the .gitignore
+  const gitProcess = HerokuCommand.exec('git ls-files -c -o --exclude-standard', { cwd: root.fsPath, signal });
+  const result = await HerokuCommand.waitForCompletion(gitProcess);
+  const paths = result.output.toString().split('\n').filter(Boolean);
+
+  const allFiles: string[] = [];
+
+  for (const p of paths) {
+    const fullPath = path.join(root.fsPath, p);
+    try {
+      const stats = await stat(fullPath);
+      if (stats.isDirectory()) {
+        // Recursively get all files in directory
+        const files = await walkDirectory(fullPath);
+        allFiles.push(...files);
+      } else {
+        allFiles.push(fullPath);
+      }
+    } catch (error) {
+      logExtensionEvent(`Failed to process path: ${fullPath}`);
+    }
+  }
+
+  return allFiles;
+}
+
+/**
+ * Walks a directory and returns a list of all files within it
+ *
+ * @param dir The directory to walk
+ * @returns A list of file paths within the directory
+ *
+ * @example
+ * const files = await walkDirectory('/path/to/directory');
+ */
+async function walkDirectory(dir: string): Promise<string[]> {
+  const files: string[] = [];
+
+  try {
+    const entries = await readdir(dir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+
+      if (entry.isDirectory()) {
+        const subFiles = await walkDirectory(fullPath);
+        files.push(...subFiles);
+      } else {
+        files.push(fullPath);
+      }
+    }
+  } catch (error) {
+    logExtensionEvent(`Failed to walk directory: ${dir}`);
+  }
+
+  return files;
 }

--- a/src/webviews/utils/map-teams-by-enterprise.ts
+++ b/src/webviews/utils/map-teams-by-enterprise.ts
@@ -9,7 +9,7 @@ import type { Team } from '@heroku-cli/schema';
 export function mapTeamsByEnterpriseAccount(teams: Team[] = []): Map<string, Team[]> {
   const teamsByEnterpriseAccountName = new Map<string, Team[]>();
   for (const team of teams) {
-    const enterpriseName = team.enterprise_account!.name as string;
+    const enterpriseName = team?.enterprise_account?.name ?? 'Not Attached to Enterprise Account';
     const teams = teamsByEnterpriseAccountName.get(enterpriseName) ?? [];
     teams.push(team);
     teamsByEnterpriseAccountName.set(enterpriseName, teams);


### PR DESCRIPTION
Fixes a condition where ignored files could be included in the tarball when deploying.

Some files listed in the .gitignore could make it in the tarball when deploying to heroku. This could happen when paths returned are relative to the root. 

GUS [W-17739289](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE0000291UO8YAM/view)