### PR TITLE
feat(W-17662545): Update command palette to include "getting started" actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2728,12 +2728,18 @@
     },
     "commands": [
       {
-        "command": "heroku:remove-app-from-workspace",
-        "title": "Remove app from workspace"
+        "command": "heroku:welcome:link:apps",
+        "title": "Link app(s) to sources",
+        "category": "Heroku apps"
       },
       {
-        "command": "heroku:addons:show-addons-view",
-        "title": "Find more add-ons"
+        "command": "heroku:welcome:github:browse",
+        "title": "Browse starter repositories",
+        "category": "Heroku apps"
+      },
+      {
+        "command": "heroku:remove-app-from-workspace",
+        "title": "Remove app from workspace"
       },
       {
         "command": "heroku:sync-with-dashboard",

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -20,6 +20,7 @@ import { LinkApp } from './commands/app/link-app';
 
 import './commands/auth/welcome-view-sign-in';
 import './commands/github/show-starter-repositories-view';
+import './commands/add-on/show-addons-view';
 import { ShowDeployAppEditor } from './commands/app/show-deploy-app-editor';
 
 const authProviderId = 'heroku:auth:login';


### PR DESCRIPTION
This PR adds the getting started actions:

1. Browser Heroku Starter Apps
2. Link Apps to command palette

### To test
1. Run this extension
2. open the command palette and type `>Heroku apps:` 
3. observe the **Browse starter repositories** and **Link app(s) to sources** in the list

Executing these command should perform their respective actions.