### PR TITLE
fix(W-17663354): add-on not appearing in resource explorer after provisioning

### DIFF
--- a/src/extension/commands/add-on/show-addons-view.ts
+++ b/src/extension/commands/add-on/show-addons-view.ts
@@ -79,7 +79,7 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
    * any pending API requests.
    */
   public [Symbol.dispose](): void {
-    this.notifier?.removeAllListeners();
+    this.notifier?.removeListener('installedAddOnsChanged', this.onInstalledAddOnsChanged);
     this.abort();
   }
 


### PR DESCRIPTION
This PR fixes an issue where addons are not shown after they are installed in certain circumstances.

This happened only when opening the Elements marketplace, closing it and then opening it again.

## Test 
1. Run the extension
2. Add at least 1 app to your workspace - ctrl + p and type `heroku apps: link`
3. Expand ADD-ONS and click "Search Elements Marketplace"
4. Install an add-on
5. Observe - the addon shows up in the ADD-ONS list after installation

[GUS](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE000028ShMEYA0/view)