### PR TITLE
feat(W-17901162): Notify the user when the Heroku CLI is not installed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         node-version: [22.x]
-        os: [sfdc-hk-ubuntu-22.04-arm-xlarge]
+        os: [pub-hk-ubuntu-22.04-small]
 
     steps:
       - name: Set up Xorg Server

--- a/src/extension/commands/heroku-cli/validate-heroku-cli.spec.ts
+++ b/src/extension/commands/heroku-cli/validate-heroku-cli.spec.ts
@@ -1,0 +1,80 @@
+import * as assert from 'node:assert';
+import sinon from 'sinon';
+import * as vscode from 'vscode';
+import { ValidateHerokuCLICommand } from './validate-heroku-cli';
+import { HerokuCommand } from '../heroku-command';
+import EventEmitter from 'node:events';
+import * as childProcess from 'node:child_process';
+
+suite('The ValidateHerokuCLICommand', () => {
+  let execStub: sinon.SinonStub;
+  let showWarningMessageStub: sinon.SinonStub;
+  let openExternalStub: sinon.SinonStub;
+  let exitCode = 0;
+  setup(() => {
+    execStub = sinon.stub(HerokuCommand, 'exec').callsFake(() => {
+      const cp = new (class extends EventEmitter {
+        public stdout = new EventEmitter();
+        public [Symbol.dispose]() {}
+      })() as unknown as childProcess.ChildProcess;
+      setTimeout(() => cp.stdout?.emit('data', 'heroku version 10.0.0'));
+      setTimeout(() => cp.emit('exit', exitCode), 50);
+      return cp;
+    });
+    showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage');
+    openExternalStub = sinon.stub(vscode.env, 'openExternal');
+  });
+
+  teardown(() => {
+    execStub.restore();
+    showWarningMessageStub.restore();
+    openExternalStub.restore();
+  });
+
+  test('is registered', async () => {
+    const commands = await vscode.commands.getCommands(true);
+    const command = commands.find((command) => command === ValidateHerokuCLICommand.COMMAND_ID);
+    assert.ok(!!command, 'The ValidateHerokuCLICommand is not registered');
+  });
+
+  test('returns true when Heroku CLI is installed', async () => {
+    const result = await vscode.commands.executeCommand<boolean>(ValidateHerokuCLICommand.COMMAND_ID);
+    assert.strictEqual(result, true);
+    assert.ok(execStub.calledWith('heroku --version'));
+    assert.ok(!showWarningMessageStub.called);
+  });
+
+  test('shows warning and returns false when Heroku CLI is not installed', async () => {
+    exitCode = 1;
+    showWarningMessageStub.resolves('Cancel');
+
+    const result = await vscode.commands.executeCommand<boolean>(ValidateHerokuCLICommand.COMMAND_ID);
+    assert.strictEqual(result, false);
+    assert.ok(
+      showWarningMessageStub.calledWith(
+        'The Heroku CLI is required to use this extension.',
+        'Cancel',
+        'Install Heroku CLI'
+      )
+    );
+  });
+
+  test('opens browser when user chooses to install Heroku CLI', async () => {
+    exitCode = 1;
+    showWarningMessageStub.resolves('Install Heroku CLI');
+    openExternalStub.resolves(true);
+
+    const result = await vscode.commands.executeCommand<boolean>(ValidateHerokuCLICommand.COMMAND_ID);
+    assert.strictEqual(result, false);
+    assert.ok(openExternalStub.calledWith(vscode.Uri.parse('https://devcenter.heroku.com/articles/heroku-cli')));
+  });
+
+  test('returns false when CLI check throws an error', async () => {
+    exitCode = 1;
+    showWarningMessageStub.resolves('Cancel');
+
+    const result = await vscode.commands.executeCommand<boolean>(ValidateHerokuCLICommand.COMMAND_ID);
+    assert.strictEqual(result, false);
+    assert.ok(showWarningMessageStub.called);
+  });
+});

--- a/src/extension/commands/heroku-cli/validate-heroku-cli.ts
+++ b/src/extension/commands/heroku-cli/validate-heroku-cli.ts
@@ -1,0 +1,43 @@
+import vscode from 'vscode';
+import { HerokuCommand } from '../heroku-command';
+import { herokuCommand } from '../../meta/command';
+import { logExtensionEvent } from '../../utils/logger';
+@herokuCommand()
+/**
+ * This command checks if the Heroku CLI is installed on the user's machine.
+ * If it is not installed, the user is prompted to install it.
+ */
+export class ValidateHerokuCLICommand extends HerokuCommand<boolean> {
+  public static readonly COMMAND_ID = 'heroku.validateHerokuCLI';
+
+  /**
+   * Executes the command to validate the Heroku CLI installation.
+   *
+   * @returns true if the Heroku CLI is installed, false otherwise.
+   */
+  public async run(): Promise<boolean> {
+    let isInstalled = true;
+    try {
+      using process = HerokuCommand.exec('heroku --version');
+      const result = await HerokuCommand.waitForCompletion(process);
+      isInstalled = result.exitCode === 0;
+    } catch (e) {
+      isInstalled = false;
+    }
+
+    if (!isInstalled) {
+      logExtensionEvent(
+        'Error: Heroku CLI not found. Visit https://devcenter.heroku.com/articles/heroku-cli to install the Heroku CLI.'
+      );
+      const items = ['Cancel', 'Install Heroku CLI'];
+      const choice = await vscode.window.showWarningMessage(
+        'The Heroku CLI is required to use this extension.',
+        ...items
+      );
+      if (choice === items[1]) {
+        void vscode.env.openExternal(vscode.Uri.parse('https://devcenter.heroku.com/articles/heroku-cli'));
+      }
+    }
+    return isInstalled;
+  }
+}

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -22,6 +22,7 @@ import './commands/auth/welcome-view-sign-in';
 import './commands/github/show-starter-repositories-view';
 import './commands/add-on/show-addons-view';
 import { ShowDeployAppEditor } from './commands/app/show-deploy-app-editor';
+import { ValidateHerokuCLICommand } from './commands/heroku-cli/validate-heroku-cli';
 
 const authProviderId = 'heroku:auth:login';
 const workspacesWithHerokuFiles: vscode.Uri[] = [];
@@ -61,6 +62,7 @@ export function activate(context: vscode.ExtensionContext): void {
   );
   void onDidChangeSessions({ provider: { id: authProviderId, label: 'Heroku' } });
   void monitorWorkspaceForHerokuAppExistence();
+  void vscode.commands.executeCommand(ValidateHerokuCLICommand.COMMAND_ID);
 }
 
 /**


### PR DESCRIPTION
This PR adds a check for the presence of the Heroku CLI upon activation of the Extension and again if the "Sign in" button is clicked from the welcome screen.

If the CLI is not located, the user is notified and presented with a "Install Heroku CLI" option.

<img width="455" alt="image" src="https://github.com/user-attachments/assets/07b112bf-2686-4f3a-97f9-25171ea2b50b" />

## To Test:
1. Remove the Heroku CLI from your system
2. Run this extension
3. Observe the above notification is visible
4. Attempt to sign in using the welcome screen "sign in" button
5. Observe the same notification is visible