### PR TITLE
feat(W-17918618): Improve startup speed

### DIFF
--- a/src/extension/commands/app/link-app.ts
+++ b/src/extension/commands/app/link-app.ts
@@ -71,22 +71,20 @@ export class LinkApp extends HerokuCommand<void> {
     if (!selected) {
       return;
     }
-    await Promise.all(
-      selected.map((quickPickItem) => {
-        if (!quickPickItem.value) {
-          return vscode.commands.executeCommand(DeployToHeroku.COMMAND_ID);
-        }
-        const flags = new Map([['remote', `heroku-${quickPickItem.value}`]]);
-        return vscode.commands.executeCommand(
-          'heroku:user:git:remote',
-          { id: quickPickItem.value, name: quickPickItem.value },
-          undefined,
-          flags
-        );
-      })
-    );
-  }
 
+    for (const item of selected) {
+      if (!item.value) {
+        await vscode.commands.executeCommand(DeployToHeroku.COMMAND_ID);
+      }
+      const flags = new Map([['remote', `heroku-${item.value}`]]);
+      await vscode.commands.executeCommand(
+        'heroku:user:git:remote',
+        { id: item.value, name: item.value },
+        undefined,
+        flags
+      );
+    }
+  }
   /**
    * Maps apps by team name
    *

--- a/src/extension/commands/auth/login.ts
+++ b/src/extension/commands/auth/login.ts
@@ -20,7 +20,7 @@ export class LoginCommand extends HerokuCommand<AuthCompletionInfo> {
 
   /**
    * Event handler for the Heroku CLI stdout.
-   * This handler looks for the promt: "Press any key to open a browser.."
+   * This handler looks for the prompt: "Press any key to open a browser.."
    * and writes a keystroke to stdin to automate the opening
    * of the browser without the need for user input.
    *
@@ -56,7 +56,7 @@ export class LoginCommand extends HerokuCommand<AuthCompletionInfo> {
     }
 
     using cliAuthProcess = HerokuCommand.exec('heroku auth:login', { signal: this.signal, timeout: 120 * 1000 });
-    cliAuthProcess.stderr?.once('data', (data: string) => LoginCommand.onData(data, cliAuthProcess));
+    cliAuthProcess.stderr?.addListener('data', (data: string) => LoginCommand.onData(data, cliAuthProcess));
 
     let success = false;
     cliAuthProcess.stdout?.addListener('data', (chunk: string) => {

--- a/src/extension/commands/auth/token.spec.ts
+++ b/src/extension/commands/auth/token.spec.ts
@@ -1,30 +1,32 @@
 import * as assert from 'node:assert';
 import sinon from 'sinon';
 import * as childProcess from 'node:child_process';
-
 import * as vscode from 'vscode';
 import { HerokuCommand } from '../heroku-command';
 import { EventEmitter } from 'node:stream';
 import { TokenCommand } from './token';
+import * as netrcLocator from '../../utils/netrc-locator';
 
 suite('The TokenCommand', () => {
   let execStub: sinon.SinonStub;
-
+  let netRcLocatorStub: sinon.SinonStub;
+  let netrcContent = '';
   setup(() => {
-    execStub = sinon.stub(HerokuCommand, 'exec').callsFake(() => {
-      const cp = new (class extends EventEmitter {
-        public stdout = new EventEmitter();
+    // Stub file system operations
+    sinon.stub(vscode.workspace, 'fs').value({
+      readFile: async () => Buffer.from(netrcContent),
+      writeFile: async () => {},
+      delete: async () => {}
+    } as unknown as vscode.FileSystem);
 
-        public [Symbol.dispose]() {}
-      })() as childProcess.ChildProcess;
-      setTimeout(() => cp.stdout?.emit('data', 'abc-123'));
-      setTimeout(() => cp.emit('exit', 0), 50);
-      return cp;
-    });
+    netRcLocatorStub = sinon.stub(netrcLocator, 'getNetrcFileLocation').resolves('netrc-file');
+
+    // Stub child process for GPG
+    execStub = sinon.stub(HerokuCommand, 'exec');
   });
 
   teardown(() => {
-    execStub.restore();
+    sinon.restore();
   });
 
   test('is registered', async () => {
@@ -33,8 +35,72 @@ suite('The TokenCommand', () => {
     assert.ok(!!command, 'The TokenCommand is not registered');
   });
 
-  test('successfully returns the auth token', async () => {
+  test('successfully reads token from unencrypted .netrc', async () => {
+    netrcContent = 'machine api.heroku.com\n  login user@example.com\n  password abc-123\nmachine api.github.com';
     const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
-    assert.equal(result, 'abc-123', `Output was ${result} but expected abc-123`);
+    assert.equal(result, 'abc-123');
+  });
+
+  test('successfully reads token from encrypted .netrc.gpg', async () => {
+    // Simulate GPG decryption
+    netRcLocatorStub.resolves('netrc-file.gpg');
+    execStub.callsFake(() => {
+      const cp = new (class extends EventEmitter {
+        public stdout = new EventEmitter();
+        public [Symbol.dispose]() {}
+      })() as childProcess.ChildProcess;
+
+      setTimeout(() =>
+        cp.stdout?.emit('data', 'machine api.heroku.com\n  login user@example.com\n  password def-456\n')
+      );
+      setTimeout(() => cp.emit('exit', 0), 50);
+      return cp;
+    });
+
+    const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
+    assert.equal(result, 'def-456');
+  });
+
+  test('returns null when no .netrc or .netrc.gpg found', async () => {
+    netRcLocatorStub.resolves(null);
+    execStub.callsFake(() => {
+      const cp = new (class extends EventEmitter {
+        public stdout = new EventEmitter();
+        public [Symbol.dispose]() {}
+      })() as childProcess.ChildProcess;
+      setTimeout(() => cp.emit('exit', 1), 50);
+      return cp;
+    });
+
+    const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
+    assert.equal(result, null);
+  });
+
+  test('returns null when no Heroku machine entry found', async () => {
+    netrcContent = 'machine api.github.com\n  login user\n  password token123';
+
+    const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
+    assert.equal(result, null);
+  });
+
+  test('handles malformed .netrc content', async () => {
+    netrcContent = 'invalid content\nno machine entries';
+
+    const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
+    assert.equal(result, null);
+  });
+
+  test('handles GPG decryption errors', async () => {
+    execStub.callsFake(() => {
+      const cp = new (class extends EventEmitter {
+        public stdout = new EventEmitter();
+        public [Symbol.dispose]() {}
+      })() as childProcess.ChildProcess;
+      setTimeout(() => cp.emit('error', new Error('GPG error')), 50);
+      return cp;
+    });
+
+    const result = await vscode.commands.executeCommand<string>(TokenCommand.COMMAND_ID);
+    assert.equal(result, null);
   });
 });

--- a/src/extension/commands/auth/whoami.spec.ts
+++ b/src/extension/commands/auth/whoami.spec.ts
@@ -45,7 +45,7 @@ suite('The WhoamiCommand', () => {
       return cp;
     });
     vsCodeExecCommandStub = sinon.stub(vscode.commands, 'executeCommand');
-    vsCodeExecCommandStub.withArgs(TokenCommand.COMMAND_ID, sinon.match.any).resolves(sessionObject.accessToken);
+    vsCodeExecCommandStub.withArgs(TokenCommand.COMMAND_ID).resolves(sessionObject.accessToken);
 
     vsCodeExecCommandStub.callThrough();
   });

--- a/src/extension/providers/authentication-provider.ts
+++ b/src/extension/providers/authentication-provider.ts
@@ -70,7 +70,8 @@ export class AuthenticationProvider
     })();
 
     const result = await this.getSessionPromise;
-    this.getSessionPromise = undefined;
+    // Keep this around for a bit in case vscode needs to call it again
+    setTimeout(() => (this.getSessionPromise = undefined), 1000);
 
     return result;
   }

--- a/src/extension/providers/resource-explorer/tree-item-generator.ts
+++ b/src/extension/providers/resource-explorer/tree-item-generator.ts
@@ -129,7 +129,7 @@ export async function getAddOnTreeItem(
   }
 
   return {
-    id: addOn.id,
+    id: `${addOn.id}:${(addOn.config_vars || []).join(',')}`,
     label: addOn.addon_service.name,
     description: `- ${addOn.state}`,
     tooltip: `${addOn.name}`,
@@ -138,7 +138,7 @@ export async function getAddOnTreeItem(
     resourceUri: vscode.Uri.parse(`heroku:/addon/${addOn.addon_service.name}`)
   } as vscode.TreeItem;
 }
-
+let emptyDynoId = 0;
 /**
  * Consumes a Dyno object and returns a TreeItem.
  *
@@ -148,7 +148,7 @@ export async function getAddOnTreeItem(
 export function getDynoTreeItem(dyno: Dyno): vscode.TreeItem {
   if (dyno.type === 'empty') {
     return {
-      id: 'empty',
+      id: 'empty:' + emptyDynoId++,
       label: 'No Dynos running',
       iconPath: new vscode.ThemeIcon('warning')
     };


### PR DESCRIPTION
This PR improves startup speeds by replacing Heroku CLI executions with optimized TypeScript where possible and by saving previously loaded apps locally.

## Test
1. Run this extension normally.
2. Link 1 or more apps to a workspace
3. Press Cmd + R to reload 
4. Observe initialization speeds carefully and note they are about 3-5 seconds faster
