### PR TITLE
feat(W-17973049): allow direct input and secure storage of an API key…

### DIFF
--- a/src/extension/commands/auth/token.ts
+++ b/src/extension/commands/auth/token.ts
@@ -1,6 +1,5 @@
-import vscode from 'vscode';
 import { herokuCommand } from '../../meta/command';
-import { getNetrcFileLocation } from '../../utils/netrc-locator';
+import { findPasswordLineNumber, getNetRcContents } from '../../utils/netrc-locator';
 import { HerokuCommand } from '../heroku-command';
 
 @herokuCommand()
@@ -20,44 +19,17 @@ export class TokenCommand extends HerokuCommand<string | null> {
    * @returns The bearer token from the .netrc file.
    */
   public async run(): Promise<string | null> {
-    const file = await getNetrcFileLocation();
-    if (!file) {
+    const netrcContents = await getNetRcContents();
+    if (netrcContents === null) {
       return null;
-    }
-    let netrcContents: string;
-    if (file.endsWith('.gpg')) {
-      const gpgProcess = HerokuCommand.exec(`gpg --batch --quiet --decrypt ${file}`);
-      const { exitCode, output } = await HerokuCommand.waitForCompletion(gpgProcess);
-      if (exitCode !== 0) {
-        return null;
-      }
-      netrcContents = output;
-    } else {
-      const netRcBuffer = await vscode.workspace.fs.readFile(vscode.Uri.parse(file));
-      netrcContents = netRcBuffer.toString();
     }
 
     // Split into lines and normalize whitespace
-    const lines = netrcContents.split('\n').map((line) => line.trim());
-
-    // Find the index of the Heroku API machine entry
-    const machineIndex = lines.findIndex((line) => line === 'machine api.heroku.com');
-
-    if (machineIndex === -1) {
+    const lines = netrcContents.split('\n');
+    const pwLine = findPasswordLineNumber(lines);
+    if (pwLine === -1) {
       return null;
     }
-
-    // Look for password in subsequent lines until we hit another machine or end
-    for (let i = machineIndex + 1; i < lines.length; i++) {
-      const line = lines[i];
-      if (line.startsWith('machine')) {
-        break;
-      }
-      if (line.startsWith('password')) {
-        return line.replace('password', '').trim();
-      }
-    }
-
-    return null;
+    return lines[pwLine].replace('password', '').trim();
   }
 }

--- a/src/extension/commands/auth/welcome-view-sign-in.ts
+++ b/src/extension/commands/auth/welcome-view-sign-in.ts
@@ -59,6 +59,5 @@ export class WelcomeViewSignIn extends HerokuCommand<boolean> {
         return false;
       }
     );
-    logExtensionEvent('Authenticating with Heroku...');
   }
 }

--- a/src/extension/commands/heroku-cli/heroku-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-command-runner.ts
@@ -117,7 +117,11 @@ export abstract class HerokuCommandRunner<T> extends HerokuCommand<void> {
   protected async executeCommand(fullyHydratedCommand: string, useTerminal?: boolean): Promise<void> {
     // fire-and-forget - no way to get output but it's a "real" terminal
     if (useTerminal) {
-      const terminal = vscode.window.createTerminal(this.commandName, vscode.env.shell, []);
+      const terminal = vscode.window.createTerminal({
+        name: this.commandName,
+        shellPath: vscode.env.shell,
+        shellArgs: []
+      });
       terminal.show();
       terminal.sendText(fullyHydratedCommand, true);
       return;

--- a/src/extension/commands/heroku-command.ts
+++ b/src/extension/commands/heroku-command.ts
@@ -14,16 +14,20 @@ export type HerokuCommandCompletionInfo = { exitCode: number | string; errorMess
  */
 export abstract class HerokuCommand<T> extends AbortController implements Disposable, RunnableCommand<T> {
   public static exec: typeof exec = exec;
+
+  protected readonly context: vscode.ExtensionContext | undefined;
   protected readonly outputChannel: vscode.OutputChannel | undefined;
 
   /**
    * Constructs a new HerokuCommand
    *
    * @param outputChannel The optional output channel. This can be used to pipe the Heroku CLI stdout or sdterr messages.
+   * @param context The extension context.
    */
-  public constructor(outputChannel?: vscode.OutputChannel) {
+  public constructor(outputChannel?: vscode.OutputChannel, context?: vscode.ExtensionContext) {
     super();
     this.outputChannel = outputChannel;
+    this.context = context;
   }
 
   /**

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -23,6 +23,7 @@ import './commands/github/show-starter-repositories-view';
 import './commands/add-on/show-addons-view';
 import { ShowDeployAppEditor } from './commands/app/show-deploy-app-editor';
 import { ValidateHerokuCLICommand } from './commands/heroku-cli/validate-heroku-cli';
+import { setExtensionContext } from './meta/command';
 
 const authProviderId = 'heroku:auth:login';
 const workspacesWithHerokuFiles: vscode.Uri[] = [];
@@ -32,6 +33,7 @@ const workspacesWithHerokuFiles: vscode.Uri[] = [];
  * @param context The extension context provided by VSCode
  */
 export function activate(context: vscode.ExtensionContext): void {
+  setExtensionContext(context);
   void context.secrets.delete(AuthenticationProvider.SESSION_KEY);
   const { authentication, languages, commands, window } = vscode;
   const selector: DocumentSelector = { scheme: 'file', language: 'shellscript' };

--- a/src/extension/utils/generate-service-request-init.ts
+++ b/src/extension/utils/generate-service-request-init.ts
@@ -7,10 +7,14 @@ const version = (Reflect.get(extension.packageJSON, 'version') as string) ?? '';
  * Generates a request init object for making API requests to the Heroku API.
  *
  * @param signal An optional abort signal to pass to the request init object.
+ * @param token An optional bearer token to pass to the request init object.
  * @returns A promise that resolves to a request init object.
  */
-export async function generateRequestInit(signal?: AbortSignal): Promise<RequestInit> {
-  const { accessToken } = (await vscode.authentication.getSession('heroku:auth:login', [])) as AuthenticationSession;
+export async function generateRequestInit(signal?: AbortSignal, token?: string): Promise<RequestInit> {
+  let accessToken = token;
+  if (!accessToken) {
+    ({ accessToken } = (await vscode.authentication.getSession('heroku:auth:login', [])) as AuthenticationSession);
+  }
   return {
     signal,
     headers: {

--- a/src/extension/utils/netrc-locator.ts
+++ b/src/extension/utils/netrc-locator.ts
@@ -1,6 +1,8 @@
 import { stat } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import vscode from 'vscode';
+import { HerokuCommand } from '../commands/heroku-command';
 /**
  * Finds the absolute path to the .netrc file
  * on disk based on the operating system. This
@@ -30,4 +32,69 @@ export async function getNetrcFileLocation(): Promise<string> {
   } catch {
     return file;
   }
+}
+
+/**
+ * Checks if encryption is available on this system via gpg.
+ *
+ * @returns boolean indicating if encryption is available on this system
+ */
+export async function canEncrypt(): Promise<boolean> {
+  try {
+    const result = await HerokuCommand.waitForCompletion(HerokuCommand.exec('gpg --version'));
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Retrieves the entire contents of the netrc file
+ * in an unencrypted string.
+ *
+ * @returns A promise resolving to the netrc file contents or null
+ */
+export async function getNetRcContents(): Promise<string | null> {
+  const file = await getNetrcFileLocation();
+  if (!file) {
+    return null;
+  }
+  let netrcContents: string;
+  if (file.endsWith('.gpg')) {
+    const gpgProcess = HerokuCommand.exec(`gpg --batch --quiet --decrypt ${file}`);
+    const { exitCode, output } = await HerokuCommand.waitForCompletion(gpgProcess);
+    if (exitCode !== 0) {
+      return null;
+    }
+    netrcContents = output;
+  } else {
+    const netRcBuffer = await vscode.workspace.fs.readFile(vscode.Uri.parse(file));
+    netrcContents = netRcBuffer.toString();
+  }
+  return netrcContents;
+}
+
+/**
+ * Finds the line number of the password entry in the netrc file for heroku.
+ *
+ * @param lines the unencrypted array of strings representing the lines of the netrc file
+ * @returns the line number of the password entry in the netrc file
+ */
+export function findPasswordLineNumber(lines: string[]): number {
+  const machineIndex = lines.findIndex((line) => line.trim() === 'machine api.heroku.com');
+  if (machineIndex === -1) {
+    return -1;
+  }
+
+  // Look for password in subsequent lines until we hit another machine or end
+  for (let i = machineIndex + 1; i < lines.length; i++) {
+    const line = lines[i].trim();
+    if (line.startsWith('machine')) {
+      break;
+    }
+    if (line.startsWith('password')) {
+      return i;
+    }
+  }
+  return -1;
 }

--- a/src/webviews/components/repo-card/index.ts
+++ b/src/webviews/components/repo-card/index.ts
@@ -170,7 +170,7 @@ export class HerokuRepoCard extends FASTElement {
   /**
    * @inheritdoc
    */
-  public declare addEventListener: <K extends keyof RepoCardEventMap>(
+  declare public addEventListener: <K extends keyof RepoCardEventMap>(
     type: K,
     listener: (this: HerokuRepoCard, ev: RepoCardEventMap[K]) => unknown,
     options?: boolean | AddEventListenerOptions
@@ -179,7 +179,7 @@ export class HerokuRepoCard extends FASTElement {
   /**
    * @inheritdoc
    */
-  public declare removeEventListener: <K extends keyof RepoCardEventMap>(
+  declare public removeEventListener: <K extends keyof RepoCardEventMap>(
     type: K,
     listener: (this: HerokuRepoCard, ev: RepoCardEventMap[K]) => unknown,
     options?: boolean | AddEventListenerOptions
@@ -188,7 +188,7 @@ export class HerokuRepoCard extends FASTElement {
   /**
    * @inheritdoc
    */
-  public declare dispatchEvent: <K extends keyof RepoCardEventMap>(
+  declare public dispatchEvent: <K extends keyof RepoCardEventMap>(
     ev: RepoCardEventMap[K]
   ) => ReturnType<typeof HTMLElement.prototype.dispatchEvent>;
 


### PR DESCRIPTION
This PR allows direct input and secure storage of an API key as an alternate auth flow for containerized vscode instances.

## To Test:
1. pack the extension into a vsix using `npx vsce pack` 
1. install and Run this extension in a containerized vscode instance such as Code Builder or Codespaces. You will need to choose "install from vsix" in the extension panel.
1. Sign in
1. Observe: A dialog will open prompting you to directly input your Heroku API key. This key can be generated via the dashboard's applications section of your settings or by running `heroku auth:token`
1. Input your Heroku API key. 
1. Observe you are now authenticated and all heroku commands work

fixes #137 

[W-17973049](https://gus.lightning.force.com/a07EE00002AgsiYYAR)