### PR TITLE
feat(W-18038467): Add  for error tracking/adoption in CLI executions

### DIFF
--- a/src/extension/commands/auth/logout.ts
+++ b/src/extension/commands/auth/logout.ts
@@ -17,7 +17,10 @@ export class LogoutCommand extends HerokuCommand<HerokuCommandCompletionInfo> {
    * @returns The uninterpreted result from the Heroku CLI child process.
    */
   public async run(): Promise<HerokuCommandCompletionInfo> {
-    using logoutProcess = HerokuCommand.exec('heroku auth:logout', { signal: this.signal });
+    using logoutProcess = HerokuCommand.exec('heroku auth:logout', {
+      signal: this.signal,
+      env: { ...process.env, HEROKU_HEADERS: await this.getCLIHeaders() }
+    });
     return await HerokuCommand.waitForCompletion(logoutProcess);
   }
 }

--- a/src/extension/commands/heroku-cli/heroku-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-command-runner.ts
@@ -132,7 +132,7 @@ export abstract class HerokuCommandRunner<T> extends HerokuCommand<void> {
     const herokuProcess = HerokuCommand.exec(fullyHydratedCommand, {
       signal: this.signal,
       windowsHide: true,
-      env: { ...process.env, FORCE_COLOR: '3' },
+      env: { ...process.env, FORCE_COLOR: '3', HEROKU_HEADERS: await this.getCLIHeaders() },
       cwd: this.getWorkingDirectory()
     });
 

--- a/src/extension/commands/heroku-cli/validate-heroku-cli.ts
+++ b/src/extension/commands/heroku-cli/validate-heroku-cli.ts
@@ -18,8 +18,10 @@ export class ValidateHerokuCLICommand extends HerokuCommand<boolean> {
   public async run(): Promise<boolean> {
     let isInstalled = true;
     try {
-      using process = HerokuCommand.exec('heroku --version');
-      const result = await HerokuCommand.waitForCompletion(process);
+      using versionProc = HerokuCommand.exec('heroku --version', {
+        env: { ...process.env, HEROKU_HEADERS: await this.getCLIHeaders() }
+      });
+      const result = await HerokuCommand.waitForCompletion(versionProc);
       isInstalled = result.exitCode === 0;
     } catch (e) {
       isInstalled = false;

--- a/src/extension/commands/heroku-command.ts
+++ b/src/extension/commands/heroku-command.ts
@@ -4,6 +4,7 @@ import { exec } from 'node:child_process';
 import fs from 'node:fs';
 import vscode from 'vscode';
 import { RunnableCommand } from '../meta/command';
+import { generateRequestInit } from '../utils/generate-service-request-init';
 
 export type HerokuCommandCompletionInfo = { exitCode: number | string; errorMessage: string; output: string };
 
@@ -130,6 +131,18 @@ export abstract class HerokuCommand<T> extends AbortController implements Dispos
       return process.cwd(); // Fallback if workspace path is inaccessible
     }
   };
+
+  /**
+   * Gets the CLI environment variables for the current session.
+   *
+   * @returns Promise<Record<string, string>>
+   */
+  protected async getCLIHeaders(): Promise<string> {
+    const { headers = {} } = await generateRequestInit();
+
+    Reflect.deleteProperty(headers, 'User-Agent');
+    return JSON.stringify(headers);
+  }
 
   public abstract run(...args: unknown[]): T | PromiseLike<T>;
 }

--- a/src/extension/utils/create-session-object.ts
+++ b/src/extension/utils/create-session-object.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as vscode from 'vscode';
 /**
  * Create an AuthenticationSession object with
@@ -7,19 +6,21 @@ import * as vscode from 'vscode';
  * @param whoami The identify of the current user
  * @param accessToken The auth token for the current user.
  * @param scopes Scopes, if any that are relevant to the session.
+ * @param userId The user id of the current user.
  * @returns AuthenticationSession
  */
 export function createSessionObject(
   whoami: string,
   accessToken: string,
-  scopes: readonly string[]
+  scopes: readonly string[],
+  userId: string
 ): vscode.AuthenticationSession {
   return {
     account: {
       id: 'Heroku',
       label: whoami
     },
-    id: randomUUID(),
+    id: userId,
     scopes,
     accessToken
   };


### PR DESCRIPTION
resolves #145 

This PR adds the `HEROKU_HEADERS` for all Heroku CLI executions

## Testing
1. Make sure heroku CLI executions still work. 

Note that I will pull eventing data a few weeks after this release to begin discovery on CLI execution failures and adoption.
[W-18038467](https://gus.lightning.force.com/a07EE00002B56JxYAJ)