### PR TITLE
chore: update git2gus config

### DIFF
--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -21,5 +21,5 @@
   },
   "includedLabels": ["feature", "bug", "question", "enhancement", "documentation"],
   "hideWorkItemUrl": "true",
-  "statusWhenClosed": "closed"
+  "statusWhenClosed": "CLOSED"
 }

--- a/.git2gus/config.json
+++ b/.git2gus/config.json
@@ -1,5 +1,5 @@
 {
-  "productTag": "a1aEE0000018vgTYAQ",
+  "productTag": "a1aEE000000dvRRYAY",
   "defaultBuild": "1",
   "issueTypeLabels": {
     "feature": "USER STORY",
@@ -20,5 +20,6 @@
     "open": "New"
   },
   "includedLabels": ["feature", "bug", "question", "enhancement", "documentation"],
-  "hideWorkItemUrl": "true"
+  "hideWorkItemUrl": "true",
+  "statusWhenClosed": "closed"
 }


### PR DESCRIPTION
Updates the git2gus config with the correct product tag and sets "statusWhenClosed" to "CLOSED" (defaults to "INTEGRATE" when not specified)