### PR TITLE
fix(deps): resolve GHSA-qj8w-gfj5-8c6v in serialize-javascript

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6603,16 +6603,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
@@ -7133,13 +7123,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -4255,5 +4255,8 @@
     "resolve.exports": "^2.0.2",
     "tar-stream": "^3.1.7",
     "tslib": "2.8.1"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.0.5"
   }
 }


### PR DESCRIPTION
## Summary

Adds an npm `overrides` entry pinning `serialize-javascript` to `^7.0.5` to resolve **GHSA-qj8w-gfj5-8c6v** (CVE-2026-34043, medium severity, CPU-exhaustion DoS via crafted array-like objects).

## Closes alert

- #35 — https://github.com/heroku/heroku-vscode/security/dependabot/35

## Why an override (last resort)

`serialize-javascript` is a transitive development dependency of `mocha`. A direct-parent upgrade is not viable today: every published stable release of `mocha` — including the current `latest` (`11.7.5`) — declares `serialize-javascript: ^6.0.2`, which is entirely below the patched `7.0.5`. Only the `mocha@12` pre-release stream declares `^7.0.2`, and pre-release / beta is not a safe target for the test runner.

| Candidate | `serialize-javascript` range | Resolves patched? | Verdict |
|---|---|---|---|
| `mocha@10.8.2` (current) | `^6.0.2` | No | rejected — vulnerable |
| `mocha@11.7.5` (latest stable) | `^6.0.2` | No | rejected — higher major doesn't help |
| `mocha@12.x` (pre-release) | `^7.0.2` | Range admits patched, but is pre-release | rejected — not a safe target |

Audit performed against the npm registry on 2026-05-06.

## Validation

- [x] `npm install` — clean install with override applied
- [x] `npm ls serialize-javascript` — single resolution, `serialize-javascript@7.0.5` under `mocha`
- [x] `npm run compile` — passes
- [x] `npm run lint` — passes
- [x] `npm test` — 104 passing, 0 failing

## Maintenance note

This override should be pruned once `mocha` ships a stable release whose declared `serialize-javascript` range admits a patched version. The repo has a dedicated override-maintenance workflow for that audit.