### PR TITLE
feat: migrate apps operations to @heroku/sdk

### DIFF
--- a/src/extension/commands/app/deploy-to-heroku.spec.ts
+++ b/src/extension/commands/app/deploy-to-heroku.spec.ts
@@ -5,10 +5,10 @@ import { DeployToHeroku } from './deploy-to-heroku';
 import { GitExtension, Repository } from '../../../../@types/git';
 import SourceService from '@heroku-cli/schema/services/source-service.js';
 import AppSetupService from '@heroku-cli/schema/services/app-setup-service.js';
-import AppService from '@heroku-cli/schema/services/app-service.js';
 import BuildService from '@heroku-cli/schema/services/build-service.js';
 import { App } from '@heroku-cli/schema';
 import { Readable, Writable } from 'node:stream';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('DeployToHeroku Tests', () => {
   let command: DeployToHeroku;
@@ -25,7 +25,7 @@ suite('DeployToHeroku Tests', () => {
     create: sinon.SinonStub;
     info: sinon.SinonStub;
   };
-  let mockAppService: Pick<AppService, 'info'> & { info: sinon.SinonStub };
+  let appInfoStub: sinon.SinonStub;
 
   let mockWorkspaceFolder: vscode.WorkspaceFolder;
   let fetchStub: typeof fetch & sinon.SinonStub;
@@ -44,9 +44,11 @@ suite('DeployToHeroku Tests', () => {
       create: sinon.stub(),
       info: sinon.stub()
     };
-    mockAppService = {
-      info: sinon.stub()
-    };
+    appInfoStub = sinon.stub();
+    sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: { app: { info: appInfoStub } },
+      data: {}
+    } as never);
 
     const readable = Readable.from(
       (async function* () {
@@ -109,7 +111,6 @@ suite('DeployToHeroku Tests', () => {
     command = new DeployToHeroku();
     Reflect.set(command, 'appSetupService', mockAppSetupService);
     Reflect.set(command, 'buildService', mockBuildService);
-    Reflect.set(command, 'appService', mockAppService);
     Reflect.set(command, 'sourcesService', mockSourcesService);
   });
 
@@ -178,7 +179,7 @@ suite('DeployToHeroku Tests', () => {
       }
     });
     mockBuildService.create.resolves(mockBuild);
-    mockAppService.info.resolves({ git_url: 'test-git-url' });
+    appInfoStub.resolves({ git_url: 'test-git-url' });
 
     await command.run(mockApp as App, null);
 
@@ -230,7 +231,7 @@ suite('DeployToHeroku Tests', () => {
       }
     });
     mockBuildService.create.resolves(mockBuild);
-    mockAppService.info.resolves({ ...mockApp, git_url: 'test-git-url' });
+    appInfoStub.resolves({ ...mockApp, git_url: 'test-git-url' });
     mockBuildService.info.resolves(mockBuild);
 
     await command.run(null, null, { appNames: ['test-id'] });

--- a/src/extension/commands/app/deploy-to-heroku.spec.ts
+++ b/src/extension/commands/app/deploy-to-heroku.spec.ts
@@ -148,6 +148,13 @@ suite('DeployToHeroku Tests', () => {
     });
     mockAppSetupService.create.resolves(mockAppSetup);
     mockAppSetupService.info.resolves(mockAppSetup);
+    // The post-create flow also calls sdk.platform.app.info(...) to
+    // fetch the new app's git_url for the remote. Stubbing it here so
+    // the path is at least covered if/when the test reaches it; today
+    // the surrounding deploy flow may short-circuit before we get
+    // there, but the stub keeps the test resilient to that internal
+    // change and avoids a silent NPE on app.git_url.
+    appInfoStub.resolves({ git_url: 'test-git-url' });
 
     await command.run(null, null);
 

--- a/src/extension/commands/app/deploy-to-heroku.ts
+++ b/src/extension/commands/app/deploy-to-heroku.ts
@@ -3,7 +3,6 @@ import vscode, { type Uri } from 'vscode';
 import { ValidatorResult } from 'jsonschema';
 import AppSetupService from '@heroku-cli/schema/services/app-setup-service.js';
 import { App, AppSetup, AppSetupCreatePayload, Build, BuildCreatePayload } from '@heroku-cli/schema';
-import AppService from '@heroku-cli/schema/services/app-service.js';
 import SourceService from '@heroku-cli/schema/services/source-service.js';
 import BuildService from '@heroku-cli/schema/services/build-service.js';
 import { herokuCommand } from '../../meta/command';
@@ -12,6 +11,7 @@ import type { AppJson, EnvironmentVariables } from '../../../../@types/app-json-
 import { logExtensionEvent, showExtensionLogs } from '../../utils/logger';
 import { packSources } from '../../utils/tarball';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import { getHerokuAppNames } from '../../utils/git-utils';
 import { uploadWithDetailedProgress } from '../../utils/upload-with-progress';
 import { readAppJson } from '../../utils/read-app-json';
@@ -80,11 +80,9 @@ class DeploymentError extends Error {
  *
  * @see {@link HerokuCommand}
  * @see {@link AppSetupService}
- * @see {@link AppService}
  */
 export class DeployToHeroku extends HerokuCommand<DeploymentResult> {
   public static COMMAND_ID = 'heroku:deploy-to-heroku';
-  protected appService = new AppService(fetch, 'https://api.heroku.com');
   protected sourcesService = new SourceService(fetch, 'https://api.heroku.com');
 
   protected appSetupService = new AppSetupService(fetch, 'https://api.heroku.com');
@@ -320,9 +318,12 @@ export class DeployToHeroku extends HerokuCommand<DeploymentResult> {
         return null;
       }
       // Check if the app exists om Heroku. If so,
-      // this is an existing app deployment
+      // this is an existing app deployment.
+      // Note: this file's existing types still use the @heroku-cli/schema App
+      // shape; cast at the SDK boundary so callers see the expected type.
       try {
-        targetApp = await this.appService.info(maybeAppName, this.requestInit);
+        const sdk = await createHerokuSDK(this.signal);
+        targetApp = (await sdk.platform.app.info(maybeAppName)) as App;
         isExistingDeployment = true;
       } catch {
         this.deploymentOptions.name = maybeAppName;
@@ -338,7 +339,8 @@ export class DeployToHeroku extends HerokuCommand<DeploymentResult> {
     if (!isExistingDeployment && result) {
       // Add the new remote to the workspace
       logExtensionEvent(`Adding remote heroku-${result.name}...`);
-      const app = await this.appService.info(result.name, this.requestInit);
+      const sdk = await createHerokuSDK(this.signal);
+      const app = await sdk.platform.app.info(result.name);
       const gitProcess = HerokuCommand.exec(`git remote add heroku-${result.name} ${app.git_url}`, {
         cwd: rootUri!.fsPath,
         signal: this.signal

--- a/src/extension/commands/app/link-app.ts
+++ b/src/extension/commands/app/link-app.ts
@@ -2,7 +2,7 @@ import type { App } from '@heroku/types/3.sdk';
 import vscode from 'vscode';
 import { herokuCommand } from '../../meta/command';
 import { HerokuCommand } from '../heroku-command';
-import { createHerokuSDK } from '../../utils/heroku-sdk';
+import { appsClient, createHerokuSDK } from '../../utils/heroku-sdk';
 import { DeployToHeroku } from './deploy-to-heroku';
 
 type PickItem = vscode.QuickPickItem & { value?: string };
@@ -25,10 +25,7 @@ export class LinkApp extends HerokuCommand<void> {
   public async run(): Promise<void> {
     const thenable = (async (): Promise<PickItem[]> => {
       const sdk = await createHerokuSDK(this.signal);
-      // Heroku's /apps endpoint paginates at 200 by default; bump the
-      // page size so accounts with more apps don't see silent
-      // truncation. SDK-side pagination is the proper fix (W-22717723).
-      const apps = await sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } }).app.list();
+      const apps = await appsClient(sdk).app.list();
       const appsByTeam = this.mapAppsByTeam(apps);
       const items = [] as PickItem[];
 

--- a/src/extension/commands/app/link-app.ts
+++ b/src/extension/commands/app/link-app.ts
@@ -25,7 +25,10 @@ export class LinkApp extends HerokuCommand<void> {
   public async run(): Promise<void> {
     const thenable = (async (): Promise<PickItem[]> => {
       const sdk = await createHerokuSDK(this.signal);
-      const apps = await sdk.platform.app.list();
+      // Heroku's /apps endpoint paginates at 200 by default; bump the
+      // page size so accounts with more apps don't see silent
+      // truncation. SDK-side pagination is the proper fix (W-22717723).
+      const apps = await sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } }).app.list();
       const appsByTeam = this.mapAppsByTeam(apps);
       const items = [] as PickItem[];
 

--- a/src/extension/commands/app/link-app.ts
+++ b/src/extension/commands/app/link-app.ts
@@ -1,9 +1,8 @@
-import AppService from '@heroku-cli/schema/services/app-service.js';
-import type { App } from '@heroku-cli/schema';
+import type { App } from '@heroku/types/3.sdk';
 import vscode from 'vscode';
 import { herokuCommand } from '../../meta/command';
 import { HerokuCommand } from '../heroku-command';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import { DeployToHeroku } from './deploy-to-heroku';
 
 type PickItem = vscode.QuickPickItem & { value?: string };
@@ -20,15 +19,13 @@ type PickItem = vscode.QuickPickItem & { value?: string };
 export class LinkApp extends HerokuCommand<void> {
   public static COMMAND_ID = 'heroku:link-app-to-sources' as const;
 
-  private appService = new AppService(fetch, 'https://api.heroku.com');
-
   /**
    * @inheritDoc
    */
   public async run(): Promise<void> {
     const thenable = (async (): Promise<PickItem[]> => {
-      const requestInit = await generateRequestInit(this.signal);
-      const apps = await this.appService.list(requestInit);
+      const sdk = await createHerokuSDK(this.signal);
+      const apps = await sdk.platform.app.list();
       const appsByTeam = this.mapAppsByTeam(apps);
       const items = [] as PickItem[];
 
@@ -90,12 +87,11 @@ export class LinkApp extends HerokuCommand<void> {
    *
    * @param apps The array of apps to map by team
    * @returns A map of apps by team
-   * @see AppService.list
    */
   private mapAppsByTeam(apps: App[]): Map<string, App[]> {
     const teams = new Map<string, App[]>();
     apps.sort((a: App, b: App) => {
-      const name = a.name.localeCompare(b.name);
+      const name = (a.name ?? '').localeCompare(b.name ?? '');
       const teamName = (a.team?.name ?? 'aaaa').localeCompare(b.team?.name ?? 'aaaa');
 
       return teamName ?? name;

--- a/src/extension/commands/app/show-deploy-app-editor.ts
+++ b/src/extension/commands/app/show-deploy-app-editor.ts
@@ -10,7 +10,7 @@ import { readAppJson } from '../../utils/read-app-json';
 import { logExtensionEvent } from '../../utils/logger';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
 import { getGithubSession, getGitRepositoryInfoByUri } from '../../utils/git-utils';
-import { createHerokuSDK } from '../../utils/heroku-sdk';
+import { appsClient, createHerokuSDK } from '../../utils/heroku-sdk';
 import { herokuCommand } from '../../meta/command';
 import { DeploymentOptions, DeployToHeroku } from './deploy-to-heroku';
 
@@ -66,14 +66,10 @@ export class ShowDeployAppEditor extends HerokuCommand<void> {
         }
       });
 
-      // Heroku's /apps endpoint paginates at 200 by default; bump the
-      // page size so accounts with more apps don't see silent
-      // truncation. SDK-side pagination is the proper fix (W-22717723).
-      const appsClient = sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } });
       const [teams, spaces, existingApps, githubSession, ...appJsonResults] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        appsClient.app.list(),
+        appsClient(sdk).app.list(),
         getGithubSession(),
         ...(this.workspaceUris?.map(readAppJson) ?? [])
       ]);

--- a/src/extension/commands/app/show-deploy-app-editor.ts
+++ b/src/extension/commands/app/show-deploy-app-editor.ts
@@ -4,13 +4,13 @@ import SpaceService from '@heroku-cli/schema/services/space-service.js';
 import { ValidatorResult } from 'jsonschema';
 import type { AppJson } from '@heroku/app-json-schema';
 import type { DeployPayload } from '@heroku/repo-card';
-import AppService from '@heroku-cli/schema/services/app-service.js';
 import { HerokuCommand } from '../heroku-command';
 import { prepareHerokuWebview } from '../../utils/prepare-heroku-web-view';
 import { readAppJson } from '../../utils/read-app-json';
 import { logExtensionEvent } from '../../utils/logger';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
 import { getGithubSession, getGitRepositoryInfoByUri } from '../../utils/git-utils';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import { herokuCommand } from '../../meta/command';
 import { DeploymentOptions, DeployToHeroku } from './deploy-to-heroku';
 
@@ -24,7 +24,6 @@ export class ShowDeployAppEditor extends HerokuCommand<void> {
 
   private teamService = new TeamService(fetch, 'https://api.heroku.com');
   private spaceService = new SpaceService(fetch, 'https://api.heroku.com');
-  private appService = new AppService(fetch, 'https://api.heroku.com');
 
   private workspaceUris: vscode.Uri[] | undefined;
   private workspaceUrlByRepoName = new Map<string, vscode.Uri>();
@@ -59,6 +58,7 @@ export class ShowDeployAppEditor extends HerokuCommand<void> {
     if (message.type === 'connected') {
       logExtensionEvent('preparing deploy to heroku editor...');
       const requestInit = await generateRequestInit(this.signal);
+      const sdk = await createHerokuSDK(this.signal);
       const repoInfos = await Promise.all(this.workspaceUris?.map(getGitRepositoryInfoByUri) ?? []);
       repoInfos.forEach((repoInfo, index) => {
         if (repoInfo) {
@@ -69,7 +69,7 @@ export class ShowDeployAppEditor extends HerokuCommand<void> {
       const [teams, spaces, existingApps, githubSession, ...appJsonResults] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        this.appService.list(requestInit),
+        sdk.platform.app.list(),
         getGithubSession(),
         ...(this.workspaceUris?.map(readAppJson) ?? [])
       ]);

--- a/src/extension/commands/app/show-deploy-app-editor.ts
+++ b/src/extension/commands/app/show-deploy-app-editor.ts
@@ -66,10 +66,14 @@ export class ShowDeployAppEditor extends HerokuCommand<void> {
         }
       });
 
+      // Heroku's /apps endpoint paginates at 200 by default; bump the
+      // page size so accounts with more apps don't see silent
+      // truncation. SDK-side pagination is the proper fix (W-22717723).
+      const appsClient = sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } });
       const [teams, spaces, existingApps, githubSession, ...appJsonResults] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        sdk.platform.app.list(),
+        appsClient.app.list(),
         getGithubSession(),
         ...(this.workspaceUris?.map(readAppJson) ?? [])
       ]);

--- a/src/extension/commands/github/show-starter-repositories-view.ts
+++ b/src/extension/commands/github/show-starter-repositories-view.ts
@@ -77,10 +77,14 @@ export class ShowStarterRepositories extends AbortController implements Runnable
       const sdk = await createHerokuSDK(this.signal);
 
       logExtensionEvent('getting teams and spaces for user');
+      // Heroku's /apps endpoint paginates at 200 by default; bump the
+      // page size so accounts with more apps don't see silent
+      // truncation. SDK-side pagination is the proper fix (W-22717723).
+      const appsClient = sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } });
       const [teams, spaces, existingApps, githubSession] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        sdk.platform.app.list(),
+        appsClient.app.list(),
         getGithubSession()
       ]);
       await ShowStarterRepositories.webviewPanel?.webview.postMessage({

--- a/src/extension/commands/github/show-starter-repositories-view.ts
+++ b/src/extension/commands/github/show-starter-repositories-view.ts
@@ -7,7 +7,7 @@ import { herokuCommand, RunnableCommand } from '../../meta/command';
 import { logExtensionEvent, showExtensionLogs } from '../../utils/logger';
 import { DeployToHeroku } from '../app/deploy-to-heroku';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
-import { createHerokuSDK } from '../../utils/heroku-sdk';
+import { appsClient, createHerokuSDK } from '../../utils/heroku-sdk';
 import { getGithubSession } from '../../utils/git-utils';
 import { prepareHerokuWebview } from '../../utils/prepare-heroku-web-view';
 import { CloneRepository } from './clone-repository';
@@ -77,14 +77,10 @@ export class ShowStarterRepositories extends AbortController implements Runnable
       const sdk = await createHerokuSDK(this.signal);
 
       logExtensionEvent('getting teams and spaces for user');
-      // Heroku's /apps endpoint paginates at 200 by default; bump the
-      // page size so accounts with more apps don't see silent
-      // truncation. SDK-side pagination is the proper fix (W-22717723).
-      const appsClient = sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } });
       const [teams, spaces, existingApps, githubSession] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        appsClient.app.list(),
+        appsClient(sdk).app.list(),
         getGithubSession()
       ]);
       await ShowStarterRepositories.webviewPanel?.webview.postMessage({

--- a/src/extension/commands/github/show-starter-repositories-view.ts
+++ b/src/extension/commands/github/show-starter-repositories-view.ts
@@ -2,12 +2,12 @@ import { promisify } from 'node:util';
 import vscode, { Uri, WebviewPanel } from 'vscode';
 import TeamService from '@heroku-cli/schema/services/team-service.js';
 import SpaceService from '@heroku-cli/schema/services/space-service.js';
-import AppService from '@heroku-cli/schema/services/app-service.js';
 import { DeployPayload } from '@heroku/repo-card';
 import { herokuCommand, RunnableCommand } from '../../meta/command';
 import { logExtensionEvent, showExtensionLogs } from '../../utils/logger';
 import { DeployToHeroku } from '../app/deploy-to-heroku';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import { getGithubSession } from '../../utils/git-utils';
 import { prepareHerokuWebview } from '../../utils/prepare-heroku-web-view';
 import { CloneRepository } from './clone-repository';
@@ -32,7 +32,6 @@ export class ShowStarterRepositories extends AbortController implements Runnable
   private static webviewPanel: WebviewPanel | undefined;
   private teamService = new TeamService(fetch, 'https://api.heroku.com');
   private spaceService = new SpaceService(fetch, 'https://api.heroku.com');
-  private appService = new AppService(fetch, 'https://api.heroku.com');
 
   /**
    * Creates and displays a webview for showing
@@ -75,12 +74,13 @@ export class ShowStarterRepositories extends AbortController implements Runnable
     if (message.type === 'connected') {
       logExtensionEvent('getting Heroku starter repos in GitHub');
       const requestInit = await generateRequestInit(this.signal);
+      const sdk = await createHerokuSDK(this.signal);
 
       logExtensionEvent('getting teams and spaces for user');
       const [teams, spaces, existingApps, githubSession] = await Promise.allSettled([
         this.teamService.list(requestInit),
         this.spaceService.list(requestInit),
-        this.appService.list(requestInit),
+        sdk.platform.app.list(),
         getGithubSession()
       ]);
       await ShowStarterRepositories.webviewPanel?.webview.postMessage({

--- a/src/extension/meta/app-json.schema.json
+++ b/src/extension/meta/app-json.schema.json
@@ -92,8 +92,7 @@
               "type": "string",
               "enum": ["secret"]
             }
-          },
-          "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false
@@ -101,20 +100,44 @@
     "dynoSize": {
       "type": "string",
       "enum": [
-        "free",
-        "eco",
-        "hobby",
-        "basic",
-        "standard-1x",
-        "standard-2x",
-        "performance-m",
-        "performance-l",
-        "private-s",
-        "private-m",
-        "private-l",
-        "shield-s",
-        "shield-m",
-        "shield-l"
+        "Eco",
+        "Basic",
+        "Standard-1X",
+        "Standard-2X",
+        "Performance-M",
+        "Performance-L",
+        "Performance-XL",
+        "Performance-2XL",
+        "Performance-L-RAM",
+        "Private-S",
+        "Private-M",
+        "Private-L",
+        "Private-XL",
+        "Private-2XL",
+        "Private-L-RAM",
+        "Shield-S",
+        "Shield-M",
+        "Shield-L",
+        "Shield-XL",
+        "Shield-2XL",
+        "Shield-L-RAM",
+        "dyno-1c-0.5gb",
+        "dyno-1c-4gb",
+        "dyno-1c-8gb",
+        "dyno-2c-1gb",
+        "dyno-2c-4gb",
+        "dyno-2c-8gb",
+        "dyno-2c-16gb",
+        "dyno-4c-8gb",
+        "dyno-4c-16gb",
+        "dyno-4c-32gb",
+        "dyno-8c-16gb",
+        "dyno-8c-32gb",
+        "dyno-8c-64gb",
+        "dyno-16c-32gb",
+        "dyno-16c-64gb",
+        "dyno-16c-128gb",
+        "dyno-32c-64gb"
       ]
     },
     "formation": {

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
@@ -5,6 +5,7 @@ import * as vscode from 'vscode';
 import { App, Dyno, Formation, AddOn } from '@heroku-cli/schema';
 import { randomUUID } from 'node:crypto';
 import * as gitUtils from '../../utils/git-utils';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 import { Readable, Writable } from 'node:stream';
 import type { HerokuResourceExplorerProvider } from './heroku-resource-explorer-provider';
 import { GitExtension, Repository } from '../../../../@types/git';
@@ -107,23 +108,22 @@ suite('HerokuResourceExplorerProvider', () => {
     sinon.stub(gitUtils, 'getHerokuAppNames').resolves(['app1']);
     sinon.stub(vscode.commands, 'registerCommand');
 
-    // The provider now reaches the SDK through createHerokuSDK; bypass
-    // the real ESM dynamic-import path and have it call our fetch stub
-    // directly so existing URL-based fixtures keep working.
-    const HerokuResourceExplorerProviderCtor = proxyquire('./heroku-resource-explorer-provider', {
-      getHerokuAppNames: () => Promise.resolve(['app1']),
-      '../../utils/heroku-sdk': {
-        createHerokuSDK: async () => ({
-          platform: {
-            app: {
-              info: async (name: string) => {
-                const res = await fetch(`https://api.heroku.com/apps/${name}`);
-                return res.json();
-              }
-            }
+    // Bypass the real ESM dynamic-import path and have createHerokuSDK
+    // delegate to our fetch stub directly so existing URL-based
+    // fixtures keep working.
+    sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        app: {
+          info: async (name: string) => {
+            const res = await fetch(`https://api.heroku.com/apps/${name}`);
+            return res.json();
           }
-        })
+        }
       }
+    } as never);
+
+    const HerokuResourceExplorerProviderCtor = proxyquire('./heroku-resource-explorer-provider', {
+      getHerokuAppNames: () => Promise.resolve(['app1'])
     }).HerokuResourceExplorerProvider;
 
     provider = new HerokuResourceExplorerProviderCtor(mockContext);

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
@@ -107,8 +107,23 @@ suite('HerokuResourceExplorerProvider', () => {
     sinon.stub(gitUtils, 'getHerokuAppNames').resolves(['app1']);
     sinon.stub(vscode.commands, 'registerCommand');
 
+    // The provider now reaches the SDK through createHerokuSDK; bypass
+    // the real ESM dynamic-import path and have it call our fetch stub
+    // directly so existing URL-based fixtures keep working.
     const HerokuResourceExplorerProviderCtor = proxyquire('./heroku-resource-explorer-provider', {
-      getHerokuAppNames: () => Promise.resolve(['app1'])
+      getHerokuAppNames: () => Promise.resolve(['app1']),
+      '../../utils/heroku-sdk': {
+        createHerokuSDK: async () => ({
+          platform: {
+            app: {
+              info: async (name: string) => {
+                const res = await fetch(`https://api.heroku.com/apps/${name}`);
+                return res.json();
+              }
+            }
+          }
+        })
+      }
     }).HerokuResourceExplorerProvider;
 
     provider = new HerokuResourceExplorerProviderCtor(mockContext);

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from 'node:events';
-import AppService from '@heroku-cli/schema/services/app-service.js';
 import type { AddOn, App, Dyno, Formation } from '@heroku-cli/schema';
 import DynoService from '@heroku-cli/schema/services/dyno-service.js';
 import vscode, { Uri } from 'vscode';
@@ -11,6 +10,7 @@ import type { LogSessionStream } from '../../commands/app/context-menu/start-log
 import { getHerokuAppNames, getRootRepository } from '../../utils/git-utils';
 import { logExtensionEvent } from '../../utils/logger';
 import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import {
   LogStreamClient,
   LogStreamEvents,
@@ -62,7 +62,6 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
   public onDidChangeTreeData: vscode.Event<T | T[] | undefined> = this.event;
 
   protected dynoService = new DynoService(fetch, 'https://api.heroku.com');
-  protected appService = new AppService(fetch, 'https://api.heroku.com');
   protected formationService = new FormationService(fetch, 'https://api.heroku.com');
 
   protected apps: Map<App['name'], LogSessionCapableApp> = new Map();
@@ -606,9 +605,13 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
     if (added.size) {
       let appsNotFound = [];
       const addedArray = Array.from(added).filter((appName) => !this.apps.has(appName));
-      const requestInit = await generateRequestInit(undefined, session.accessToken);
+      // The resource explorer's internal types are still tied to the
+      // legacy @heroku-cli/schema App shape; cast at the boundary so
+      // the rest of the file stays unchanged. Drop the cast once the
+      // file is fully migrated off the schema package.
+      const sdk = await createHerokuSDK(undefined, session.accessToken);
       const appResults = await Promise.allSettled(
-        addedArray.map((appName) => this.appService.info(appName, requestInit))
+        addedArray.map((appName) => sdk.platform.app.info(appName) as Promise<App>)
       );
       for (let i = 0; i < appResults.length; i++) {
         const result = appResults[i];

--- a/src/extension/utils/heroku-sdk.ts
+++ b/src/extension/utils/heroku-sdk.ts
@@ -17,6 +17,17 @@ const TELEMETRY_HEADERS = {
  * via `withOptions` so callers can write `sdk.platform.app.list()`
  * and still get cancellation on disposal.
  *
+ * The signal is bound at construction and shared by every call made
+ * through the returned SDK. That matches our usage — callers want the
+ * lifecycle signal of the unit of work (typically `HerokuCommand`) to
+ * abort every in-flight request when the command is disposed. Do not
+ * stash the returned SDK on a longer-lived owner: once the captured
+ * signal aborts, every subsequent call through that SDK rejects.
+ *
+ * If a single call needs a different signal, override per-call via
+ * `withOptions` (last-one-wins): `sdk.platform.withOptions({signal:
+ * other}).app.info(...)`.
+ *
  * Pass `token` only when there is no active session yet (e.g. inside
  * the login flow itself); otherwise the helper resolves the token
  * from `vscode.authentication.getSession`.

--- a/src/extension/utils/heroku-sdk.ts
+++ b/src/extension/utils/heroku-sdk.ts
@@ -1,0 +1,71 @@
+import type { HerokuSDK } from '@heroku/sdk';
+import vscode from 'vscode';
+
+const extension = vscode.extensions.getExtension('Heroku-Dev-Tools.heroku') ?? { packageJSON: {} };
+const version = (Reflect.get(extension.packageJSON, 'version') as string) ?? '';
+
+const TELEMETRY_HEADERS = {
+  Referer: `vscode-heroku-extension/${version}`,
+  'User-Agent': `VSCode-Heroku-Extension/${version} (${process.platform}; ${process.arch}) VSCode/${vscode.version}`
+} as const;
+
+/**
+ * Creates a HerokuSDK pre-configured for the VS Code extension:
+ * VS Code authentication session as the token source, telemetry
+ * headers (Referer / User-Agent / X-Account-Id), and an optional
+ * AbortSignal pre-applied to both `platform` and `data` namespaces
+ * via `withOptions` so callers can write `sdk.platform.app.list()`
+ * and still get cancellation on disposal.
+ *
+ * Pass `token` only when there is no active session yet (e.g. inside
+ * the login flow itself); otherwise the helper resolves the token
+ * from `vscode.authentication.getSession`.
+ *
+ * @param signal Optional AbortSignal threaded into every route call.
+ * @param token Optional explicit bearer token; falls back to the
+ *   active VS Code authentication session when omitted.
+ * @returns An SDK exposing `platform` and `data` namespaces.
+ * @example
+ * ```ts
+ * const sdk = await createHerokuSDK(this.signal);
+ * const apps = await sdk.platform.app.list();
+ * ```
+ */
+export async function createHerokuSDK(
+  signal?: AbortSignal,
+  token?: string
+): Promise<Pick<HerokuSDK, 'data' | 'platform'>> {
+  const session = token ? undefined : await vscode.authentication.getSession('heroku:auth:login', []);
+
+  const headers: Record<string, string> = { ...TELEMETRY_HEADERS };
+  if (session?.id) {
+    headers['X-Account-Id'] = session.id;
+  }
+
+  const resolvedToken = token?.trim() ?? session?.accessToken?.trim() ?? '';
+
+  // `@heroku/sdk` ships ESM only and uses top-level await, which CJS
+  // cannot `require`. This extension is compiled to CJS, so reach the
+  // SDK via a real dynamic `import()`. The `eval` wrapper keeps TS's
+  // NodeNext mode from rewriting the import into a `require` during
+  // compilation.
+  // eslint-disable-next-line no-eval
+  const { HerokuSDK: HerokuSDKCtor } = (await (0, eval)('import("@heroku/sdk")')) as typeof import('@heroku/sdk');
+  const sdk = new HerokuSDKCtor({
+    clientOptions: {
+      headers,
+      token: resolvedToken
+    }
+  });
+
+  if (!signal) return sdk;
+
+  return {
+    get data(): HerokuSDK['data'] {
+      return sdk.data.withOptions({ signal }) as HerokuSDK['data'];
+    },
+    get platform(): HerokuSDK['platform'] {
+      return sdk.platform.withOptions({ signal }) as HerokuSDK['platform'];
+    }
+  };
+}

--- a/src/extension/utils/heroku-sdk.ts
+++ b/src/extension/utils/heroku-sdk.ts
@@ -80,3 +80,27 @@ export async function createHerokuSDK(
     }
   };
 }
+
+/**
+ * Returns a `platform` client wrapped to request a larger
+ * `app.list` page than the API default of 200, so accounts with many
+ * apps don't see silent truncation.
+ *
+ * Temporary helper until the SDK ships native list-pagination
+ * (W-22717723). Callers use it like:
+ *
+ * ```ts
+ * const apps = await appsClient(sdk).app.list();
+ * ```
+ *
+ * The 1000 ceiling matches what the Platform tolerates in a single
+ * `Range` request and is enough for everyone we know about today.
+ *
+ * @param sdk An SDK (typically from `createHerokuSDK`) whose
+ *   `platform` namespace will be wrapped.
+ * @returns A platform client whose every call carries the bumped
+ *   `Range` header.
+ */
+export function appsClient(sdk: Pick<HerokuSDK, 'platform'>): HerokuSDK['platform'] {
+  return sdk.platform.withOptions({ headers: { Range: 'name ..; max=1000;' } }) as HerokuSDK['platform'];
+}


### PR DESCRIPTION
## Summary

Migrates the VS Code extension's `apps.list` and `apps.info` calls from `@heroku-cli/schema`'s `AppService` to `@heroku/sdk`'s `platform.app` resource. Five call sites:

| File | Method |
|---|---|
| `commands/app/link-app.ts` | `app.list` |
| `commands/app/show-deploy-app-editor.ts` | `app.list` |
| `commands/github/show-starter-repositories-view.ts` | `app.list` |
| `commands/app/deploy-to-heroku.ts` | `app.info` × 2 |
| `providers/resource-explorer/heroku-resource-explorer-provider.ts` | `app.info` |

App **creation** via `appSetupService.create()` is intentionally left alone — that's a separate WI.

### `createHerokuSDK` helper

New `src/extension/utils/heroku-sdk.ts`. Builds an SDK pre-configured for the extension:
- VS Code authentication session as the token source
- Telemetry headers (`Referer`, `User-Agent`, `X-Account-Id`)
- Optional `AbortSignal` applied to both `platform` and `data` namespaces via `withOptions`, so callers write `(await createHerokuSDK(this.signal)).platform.app.list()` and get cancellation-on-disposal for free

### Dynamic ESM import

`@heroku/sdk` (and `@heroku/heroku-fetch` underneath) ship ESM only and use top-level await. This extension is compiled to CJS, which can't `require()` such modules. The helper reaches the SDK via a real dynamic `import()` (eval-wrapped so TS's NodeNext mode doesn't rewrite it back to `require` during compilation).

### Page-size bump on `app.list` calls

Heroku's `GET /apps` endpoint paginates at 200 by default. The legacy `AppService.list()` and `sdk.platform.app.list()` both made a single request — accounts with more than 200 apps saw silent truncation. All three migrated `app.list` call sites now pass `Range: name ..; max=1000;` via `withOptions`. SDK-side pagination is filed as a follow-up: **W-22717723**.

### `app.json` schema fix

Two stale-schema bugs surfaced while testing against `~/particleboard`. Found and fixed in this PR; tracked separately as **W-22718013**:

1. **`env.<VAR>` rejected extra properties.** Schema had `additionalProperties: false` on each env entry. Platform API silently tolerates extras (e.g. `default`). Removed the constraint on the entry pattern.
2. **`formation.<type>.size` enum was stale.** Schema enum was lowercase (`standard-1x`, `private-m`). Platform API canonical names are PascalCase (`Standard-1X`, `Private-M`) plus a Fir-generation set (`dyno-1c-4gb`, etc.). Rebuilt from `GET /dyno-sizes`. Long-term fix is to validate against a live `dynoSize.list()` call — **W-22718031**.

### Type migration

For `link-app.ts` (a self-contained file with no `App`-typed boundaries leaving it), the `App` import switched from `@heroku-cli/schema` to `@heroku/types/3.sdk`. Other files keep the schema's `App` type internally and cast at the SDK boundary — those `App` types thread through too many existing types to retype safely in this WI.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: Verified end-to-end against a real account. Replace `<test-app>` with one of your apps for the resource-explorer step.

**Steps**:
1. `npm run compile && npm run lint && npm test` — expect 104 passing.
2. F5 to launch Extension Host. In the new window: open a workspace with a `heroku` git remote (e.g. `~/workspace/node-workers-example` after `heroku git:remote -a <test-app>`).
3. Cmd+Shift+P → "Heroku: Link App to Sources" — quickpick should populate with your apps grouped by team. Apps past the old 200-result cutoff should now appear.
4. Open the Heroku Resource Explorer in the activity bar — your linked app should resolve with formations/dynos/add-ons (exercises `app.info`).
5. From the welcome view, click "Deploy to Heroku" — the deploy editor webview should populate the existing-apps dropdown (exercises `app.list` with the page-size bump).
6. (Optional) Open DevTools (Help → Toggle Developer Tools) → Network. Confirm requests to `https://api.heroku.com/apps*` carry `Authorization: Bearer ...`, `Referer: vscode-heroku-extension/...`, `User-Agent: VSCode-Heroku-Extension/...`, and (on list calls) `Range: name ..; max=1000;`.
7. (Optional) Open `~/particleboard` and click "Deploy to Heroku" — `app.json` validation should now pass with PascalCase dyno sizes and `default`-bearing env entries.

## Screenshots (if applicable)

## Related Issues
GitHub issue:
GUS work item: [W-22264762](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z0NEIYA3/view)

Follow-ups filed during this work:
- [W-22717723](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b5GRXYA2/view) — SDK pagination helpers for collection routes
- [W-22718013](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b5SIQYA2/view) — fixed in this PR
- [W-22718031](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002b5UFdYAM/view) — SDK-driven dyno-size validation