### PR TITLE
feat: migrate add-on operations to @heroku/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#eb/add-on-pricing-and-plans-for-addon",
+        "@heroku/sdk": "github:heroku/heroku-sdk#main",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -580,7 +580,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#00487ef67a0884419c28015d58a018c297ff83bf",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#ea41870c186fdc8dc0affc12e8b4a6a94d2240da",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#main",
+        "@heroku/sdk": "github:heroku/heroku-sdk#eb/add-on-pricing-and-plans-for-addon",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -580,7 +580,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#be2b09708f210f7780f28b80a56343453173e82a",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#00487ef67a0884419c28015d58a018c297ff83bf",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",

--- a/package.json
+++ b/package.json
@@ -4245,7 +4245,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#eb/add-on-pricing-and-plans-for-addon",
+    "@heroku/sdk": "github:heroku/heroku-sdk#main",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -4245,7 +4245,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#main",
+    "@heroku/sdk": "github:heroku/heroku-sdk#eb/add-on-pricing-and-plans-for-addon",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/src/extension/commands/add-on/list-by-app.ts
+++ b/src/extension/commands/add-on/list-by-app.ts
@@ -20,11 +20,11 @@ export class ListAddOnsByApp extends AbortController implements RunnableCommand<
   public async run(appIdentifier: string, debounce = true): Promise<AddOn[]> {
     let request = ListAddOnsByApp.debounceRequestsByApp.get(appIdentifier);
     if (!request || !debounce) {
-      const sdk = await createHerokuSDK(this.signal);
+      const { platform } = await createHerokuSDK(this.signal);
       // The resource explorer's existing types are tied to the
       // legacy @heroku-cli/schema AddOn shape; cast at the boundary
       // so the rest of the file stays unchanged.
-      request = sdk.platform.addOn.listByApp(appIdentifier) as Promise<AddOn[]>;
+      request = platform.addOn.listByApp(appIdentifier) as Promise<AddOn[]>;
     }
     if (debounce) {
       ListAddOnsByApp.debounceRequestsByApp.set(appIdentifier, request);

--- a/src/extension/commands/add-on/list-by-app.ts
+++ b/src/extension/commands/add-on/list-by-app.ts
@@ -1,7 +1,6 @@
 import type { AddOn } from '@heroku-cli/schema';
-import AddOnService from '@heroku-cli/schema/services/add-on-service.js';
 import { herokuCommand, type RunnableCommand } from '../../meta/command';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 
 @herokuCommand()
 /**
@@ -10,8 +9,6 @@ import { generateRequestInit } from '../../utils/generate-service-request-init';
 export class ListAddOnsByApp extends AbortController implements RunnableCommand<AddOn[]> {
   public static COMMAND_ID = 'heroku:addons:list-by-app' as const;
   private static debounceRequestsByApp = new Map<string, Promise<AddOn[]>>();
-
-  protected addOnService = new AddOnService(fetch, 'https://api.heroku.com');
 
   /**
    * Constructs a new instance of the ListAddOnsByApp class
@@ -23,8 +20,11 @@ export class ListAddOnsByApp extends AbortController implements RunnableCommand<
   public async run(appIdentifier: string, debounce = true): Promise<AddOn[]> {
     let request = ListAddOnsByApp.debounceRequestsByApp.get(appIdentifier);
     if (!request || !debounce) {
-      const requestInit = await generateRequestInit(this.signal);
-      request = this.addOnService.listByApp(appIdentifier, requestInit);
+      const sdk = await createHerokuSDK(this.signal);
+      // The resource explorer's existing types are tied to the
+      // legacy @heroku-cli/schema AddOn shape; cast at the boundary
+      // so the rest of the file stays unchanged.
+      request = sdk.platform.addOn.listByApp(appIdentifier) as Promise<AddOn[]>;
     }
     if (debounce) {
       ListAddOnsByApp.debounceRequestsByApp.set(appIdentifier, request);

--- a/src/extension/commands/add-on/show-addons-view.ts
+++ b/src/extension/commands/add-on/show-addons-view.ts
@@ -1,12 +1,10 @@
 import EventEmitter from 'node:events';
 import vscode, { WebviewPanel } from 'vscode';
-import PlanService from '@heroku-cli/schema/services/plan-service.js';
-import AddOnService from '@heroku-cli/schema/services/add-on-service.js';
 import { AddOn } from '@heroku-cli/schema';
 import { CategoriesResponse } from '@heroku/elements';
 import { herokuCommand, RunnableCommand } from '../../meta/command';
 import { prepareHerokuWebview } from '../../utils/prepare-heroku-web-view';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 
 type MessagePayload =
   | {
@@ -36,8 +34,6 @@ type MessagePayload =
 export class ShowAddonsViewCommand extends AbortController implements RunnableCommand<Promise<void>> {
   public static COMMAND_ID = 'heroku:addons:show-addons-view' as const;
   private static addonsPanel: WebviewPanel | undefined;
-  private planService = new PlanService(fetch, 'https://api.heroku.com');
-  private addonService = new AddOnService(fetch, 'https://api.heroku.com');
 
   private appIdentifier!: string;
   private notifier: EventEmitter | undefined;
@@ -93,7 +89,8 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
       case 'addons':
         {
           const addonsByCategoryResponse = await fetch('https://addons.heroku.com/api/v2/categories');
-          const installedAddons = await this.addonService.listByApp(this.appIdentifier, await generateRequestInit());
+          const sdk = await createHerokuSDK(this.signal);
+          const installedAddons = await sdk.platform.addOn.listByApp(this.appIdentifier);
           if (addonsByCategoryResponse.ok) {
             const addons = (await addonsByCategoryResponse.json()) as CategoriesResponse;
             await webview.postMessage({ type: 'addons', payload: { categories: addons.categories, installedAddons } });
@@ -104,7 +101,8 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
       case 'addonPlans':
         {
           try {
-            const addonPlans = await this.planService.listByAddOn(message.id, await generateRequestInit());
+            const sdk = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
+            const addonPlans = await sdk.platform.addOn.listPlans(message.id);
             await webview.postMessage({ type: 'addonPlans', payload: addonPlans, id: message.id });
           } catch {
             // no-op
@@ -147,17 +145,17 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
   ): Promise<void> {
     const { webview } = ShowAddonsViewCommand.addonsPanel as WebviewPanel;
     try {
-      const requestInit = await generateRequestInit();
+      const sdk = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
       let newlyCreatedOrUpdatedAddon: AddOn;
       if (type === 'installAddon') {
-        newlyCreatedOrUpdatedAddon = await this.addonService.create(this.appIdentifier, { plan }, requestInit);
+        newlyCreatedOrUpdatedAddon = (await sdk.platform.addOn.create(this.appIdentifier, { plan })) as AddOn;
       } else {
-        newlyCreatedOrUpdatedAddon = await this.addonService.update(
-          this.appIdentifier,
-          installedAddonId as string,
-          { plan },
-          requestInit
-        );
+        // Use the SDK's `upgrade` extension rather than a raw `update`:
+        // it resolves the add-on identity first and qualifies the plan
+        // name with the addon_service prefix when needed. The webview
+        // already passes a fully-qualified plan, so qualification is a
+        // no-op here, but the resolve adds safety.
+        newlyCreatedOrUpdatedAddon = (await sdk.platform.addOn.upgrade(installedAddonId as string, plan)) as AddOn;
       }
 
       await webview.postMessage({ type: 'addonCreated', payload: newlyCreatedOrUpdatedAddon, id: addOnId });

--- a/src/extension/commands/add-on/show-addons-view.ts
+++ b/src/extension/commands/add-on/show-addons-view.ts
@@ -89,8 +89,8 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
       case 'addons':
         {
           const addonsByCategoryResponse = await fetch('https://addons.heroku.com/api/v2/categories');
-          const sdk = await createHerokuSDK(this.signal);
-          const installedAddons = await sdk.platform.addOn.listByApp(this.appIdentifier);
+          const { platform } = await createHerokuSDK(this.signal);
+          const installedAddons = await platform.addOn.listByApp(this.appIdentifier);
           if (addonsByCategoryResponse.ok) {
             const addons = (await addonsByCategoryResponse.json()) as CategoriesResponse;
             await webview.postMessage({ type: 'addons', payload: { categories: addons.categories, installedAddons } });
@@ -101,8 +101,8 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
       case 'addonPlans':
         {
           try {
-            const sdk = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
-            const addonPlans = await sdk.platform.addOn.listPlans(message.id);
+            const { platform } = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
+            const addonPlans = await platform.addOn.listPlans(message.id);
             await webview.postMessage({ type: 'addonPlans', payload: addonPlans, id: message.id });
           } catch {
             // no-op
@@ -145,17 +145,17 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
   ): Promise<void> {
     const { webview } = ShowAddonsViewCommand.addonsPanel as WebviewPanel;
     try {
-      const sdk = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
+      const { platform } = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
       let newlyCreatedOrUpdatedAddon: AddOn;
       if (type === 'installAddon') {
-        newlyCreatedOrUpdatedAddon = (await sdk.platform.addOn.create(this.appIdentifier, { plan })) as AddOn;
+        newlyCreatedOrUpdatedAddon = (await platform.addOn.create(this.appIdentifier, { plan })) as AddOn;
       } else {
         // Use the SDK's `upgrade` extension rather than a raw `update`:
         // it resolves the add-on identity first and qualifies the plan
         // name with the addon_service prefix when needed. The webview
         // already passes a fully-qualified plan, so qualification is a
         // no-op here, but the resolve adds safety.
-        newlyCreatedOrUpdatedAddon = (await sdk.platform.addOn.upgrade(installedAddonId as string, plan)) as AddOn;
+        newlyCreatedOrUpdatedAddon = (await platform.addOn.upgrade(installedAddonId as string, plan)) as AddOn;
       }
 
       await webview.postMessage({ type: 'addonCreated', payload: newlyCreatedOrUpdatedAddon, id: addOnId });

--- a/src/extension/commands/add-on/show-addons-view.ts
+++ b/src/extension/commands/add-on/show-addons-view.ts
@@ -150,11 +150,6 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
       if (type === 'installAddon') {
         newlyCreatedOrUpdatedAddon = (await platform.addOn.create(this.appIdentifier, { plan })) as AddOn;
       } else {
-        // Use the SDK's `upgrade` extension rather than a raw `update`:
-        // it resolves the add-on identity first and qualifies the plan
-        // name with the addon_service prefix when needed. The webview
-        // already passes a fully-qualified plan, so qualification is a
-        // no-op here, but the resolve adds safety.
         newlyCreatedOrUpdatedAddon = (await platform.addOn.upgrade(installedAddonId as string, plan)) as AddOn;
       }
 

--- a/src/extension/commands/add-on/show-addons-view.ts
+++ b/src/extension/commands/add-on/show-addons-view.ts
@@ -5,6 +5,7 @@ import { CategoriesResponse } from '@heroku/elements';
 import { herokuCommand, RunnableCommand } from '../../meta/command';
 import { prepareHerokuWebview } from '../../utils/prepare-heroku-web-view';
 import { createHerokuSDK } from '../../utils/heroku-sdk';
+import { logExtensionEvent } from '../../utils/logger';
 
 type MessagePayload =
   | {
@@ -88,12 +89,25 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
     switch (message.type) {
       case 'addons':
         {
-          const addonsByCategoryResponse = await fetch('https://addons.heroku.com/api/v2/categories');
-          const { platform } = await createHerokuSDK(this.signal);
-          const installedAddons = await platform.addOn.listByApp(this.appIdentifier);
-          if (addonsByCategoryResponse.ok) {
-            const addons = (await addonsByCategoryResponse.json()) as CategoriesResponse;
-            await webview.postMessage({ type: 'addons', payload: { categories: addons.categories, installedAddons } });
+          try {
+            const addonsByCategoryResponse = await fetch('https://addons.heroku.com/api/v2/categories');
+            const { platform } = await createHerokuSDK(this.signal);
+            const installedAddons = await platform.addOn.listByApp(this.appIdentifier);
+            if (addonsByCategoryResponse.ok) {
+              const addons = (await addonsByCategoryResponse.json()) as CategoriesResponse;
+              await webview.postMessage({
+                type: 'addons',
+                payload: { categories: addons.categories, installedAddons }
+              });
+            }
+          } catch (e) {
+            // The user closed the panel — propagate via abort, no UI signal.
+            if (this.signal.aborted) {
+              return;
+            }
+            const { message: errorMessage } = e as Error;
+            logExtensionEvent(`Failed to load add-ons for ${this.appIdentifier}: ${errorMessage}`);
+            await vscode.window.showErrorMessage(`Failed to load add-ons: ${errorMessage}`);
           }
         }
         break;
@@ -104,8 +118,14 @@ export class ShowAddonsViewCommand extends AbortController implements RunnableCo
             const { platform } = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
             const addonPlans = await platform.addOn.listPlans(message.id);
             await webview.postMessage({ type: 'addonPlans', payload: addonPlans, id: message.id });
-          } catch {
-            // no-op
+          } catch (e) {
+            // The user closed the panel — propagate via abort, no UI signal.
+            if (this.signal.aborted) {
+              return;
+            }
+            const { message: errorMessage } = e as Error;
+            logExtensionEvent(`Failed to load plans for add-on ${message.id}: ${errorMessage}`);
+            await webview.postMessage({ type: 'addonPlansFailed', payload: errorMessage, id: message.id });
           }
         }
         break;

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
@@ -51,7 +51,15 @@ suite('The HerokuAddOnCommandRunner', () => {
       } as Plan
     ]);
     Sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
-      platform: { addOn: { listPlans: planServiceStub } },
+      platform: {
+        addOn: {
+          listPlansForAddon: planServiceStub,
+          // The pure helper now lives on the factory too. Stub it
+          // with a deterministic suffix so the test asserts the
+          // composition, not the formatter's internals.
+          formatPlanPriceLabel: (plan: Plan) => `\$${plan.price.cents / 100} / hour`
+        }
+      },
       data: {}
     } as never);
 

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
@@ -102,11 +102,64 @@ suite('The HerokuAddOnCommandRunner', () => {
     const options = upgradePlanArgs.options as unknown as Promise<(vscode.QuickPickItem & { value: string })[]>;
 
     const result = await options;
+    // The 4 items are: separator "Basic", Basic Plan, separator "Pro", Pro Plan.
     assert.strictEqual(result?.length, 4, 'Incorrect number of plan options returned.');
-    assert.ok(result[1].label.includes('Basic Plan'), 'Basic Plan option is missing or incorrect.');
+
+    // Basic Plan = 1000 cents → stub returns "$10 / hour"
+    assert.strictEqual(
+      result[1].label,
+      'Basic Plan - $10 / hour',
+      'Basic Plan label should compose human_name with the formatPlanPriceLabel suffix.'
+    );
     assert.strictEqual(result[1].value, 'basic', 'Basic Plan value is incorrect.');
 
+    // Pro Plan = 5000 cents → stub returns "$50 / hour"
+    assert.strictEqual(
+      result[3].label,
+      'Pro Plan - $50 / hour',
+      'Pro Plan label should compose human_name with the formatPlanPriceLabel suffix.'
+    );
+    assert.strictEqual(result[3].value, 'pro', 'Pro Plan value is incorrect.');
+
     assert.ok(planServiceStub.calledOnce, 'The plan service was not called.');
+  });
+
+  test('injectPlanOptionsIntoCommand omits the suffix when formatPlanPriceLabel returns an empty string', async () => {
+    // Real-world case: metered or contract-priced plans return ''
+    // from formatPlanPriceLabel. The label should fall back to just
+    // the human_name without a trailing " - ".
+    Sinon.restore();
+    const meteredStub = Sinon.stub();
+    meteredStub.resolves([
+      {
+        human_name: 'Metered Plan',
+        name: 'metered',
+        id: 'metered-id',
+        price: { cents: 0 } as Price,
+        description: 'pay per use'
+      } as Plan
+    ]);
+    Sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        addOn: {
+          listPlansForAddon: meteredStub,
+          formatPlanPriceLabel: () => ''
+        }
+      },
+      data: {}
+    } as never);
+
+    const upgradePlanArgs = {} as Command.Arg;
+    await runner['injectPlanOptionsIntoCommand'](upgradePlanArgs, mockAddOn);
+    const options = upgradePlanArgs.options as unknown as Promise<(vscode.QuickPickItem & { value: string })[]>;
+    const result = await options;
+
+    // result[0] is the section separator; result[1] is the plan.
+    assert.strictEqual(
+      result[1].label,
+      'Metered Plan',
+      'Plan label should be human_name alone when formatPlanPriceLabel returns empty.'
+    );
   });
 
   test('injectAttachmentOptionsIntoCommand adds attachment options for addons:detach command', async () => {

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.spec.ts
@@ -4,9 +4,9 @@ import Sinon, { type SinonMock, type SinonStub } from 'sinon';
 import LogSessionService from '@heroku-cli/schema/services/log-session-service.js';
 import type { AddOnAttachment, App, LogSession, Plan, Price } from '@heroku-cli/schema';
 import { HerokuAddOnCommandRunner } from './heroku-addon-command-runner';
-import PlanService from '@heroku-cli/schema/services/plan-service.js';
 import AddOnAttachmentService from '@heroku-cli/schema/services/add-on-attachment-service.js';
 import { Command } from '@oclif/config';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('The HerokuAddOnCommandRunner', () => {
   let logServiceStub: SinonStub;
@@ -33,7 +33,8 @@ suite('The HerokuAddOnCommandRunner', () => {
       accessToken: 'token'
     } as vscode.AuthenticationSession);
 
-    planServiceStub = Sinon.stub(PlanService.prototype, 'listByAddOn').resolves([
+    planServiceStub = Sinon.stub();
+    planServiceStub.resolves([
       {
         human_name: 'Basic Plan',
         name: 'basic',
@@ -49,6 +50,10 @@ suite('The HerokuAddOnCommandRunner', () => {
         description: 'Pro plan'
       } as Plan
     ]);
+    Sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: { addOn: { listPlans: planServiceStub } },
+      data: {}
+    } as never);
 
     attachmentServiceStub = Sinon.stub(AddOnAttachmentService.prototype, 'listByAddOn').resolves([
       { name: 'Attachment 1', id: 'attachment-1' } as AddOnAttachment,
@@ -94,7 +99,6 @@ suite('The HerokuAddOnCommandRunner', () => {
     assert.strictEqual(result[1].value, 'basic', 'Basic Plan value is incorrect.');
 
     assert.ok(planServiceStub.calledOnce, 'The plan service was not called.');
-    assert.ok(authStub.calledOnce, 'The authentication service was not called.');
   });
 
   test('injectAttachmentOptionsIntoCommand adds attachment options for addons:detach command', async () => {

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
@@ -68,9 +68,9 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
       return;
     }
     const thenable = (async (): Promise<vscode.QuickPickItem[]> => {
-      const sdk = await createHerokuSDK(undefined, undefined, ['addOnExtensions']);
+      const { platform } = await createHerokuSDK(undefined, undefined, ['addOnExtensions']);
       // Cast to schema Plan since the rest of this file uses that type.
-      const plans = (await sdk.platform.addOn.listPlansForAddon(addOn.id)) as unknown as Plan[];
+      const plans = (await platform.addOn.listPlansForAddon(addOn.id)) as unknown as Plan[];
       const items: vscode.QuickPickItem[] = [];
       let lastPlanPrefix = '';
 
@@ -85,7 +85,7 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
           });
         }
         lastPlanPrefix = planPrefix;
-        const priceSuffix = sdk.platform.addOn.formatPlanPriceLabel(plan as never);
+        const priceSuffix = platform.addOn.formatPlanPriceLabel(plan as never);
         items.push({
           label: priceSuffix ? `${plan.human_name} - ${priceSuffix}` : plan.human_name,
           description: plan.description,

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
@@ -1,10 +1,10 @@
-import type { AddOn } from '@heroku-cli/schema';
-import PlanService from '@heroku-cli/schema/services/plan-service.js';
+import type { AddOn, Plan } from '@heroku-cli/schema';
 import vscode from 'vscode';
 import type { Command } from '@oclif/config';
 import AddOnAttachmentService from '@heroku-cli/schema/services/add-on-attachment-service.js';
 import type { CommandMeta } from '../../manifest';
 import { herokuCommand, HerokuOutputChannel } from '../../meta/command';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 import { HerokuContextMenuCommandRunner } from './heroku-context-menu-command-runner';
 
 @herokuCommand({ outputChannelId: HerokuOutputChannel.CommandOutput })
@@ -67,15 +67,13 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
     if (!addOn) {
       return;
     }
-    const planService = new PlanService(fetch, 'https://api.heroku.com');
     const thenable = (async (): Promise<vscode.QuickPickItem[]> => {
-      const { accessToken } = (await vscode.authentication.getSession(
-        'heroku:auth:login',
-        []
-      )) as vscode.AuthenticationSession;
-      const plans = await planService.listByAddOn(addOn.addon_service.id, {
-        headers: { Authorization: `Bearer ${accessToken}` }
-      });
+      const sdk = await createHerokuSDK(undefined, undefined, ['addOnExtensions']);
+      // The SDK's listPlans extension returns plans sorted by price
+      // ascending. The downstream code below regroups them by human_name
+      // prefix; the price-sort within each group is the same as before.
+      // Cast to schema Plan since the rest of this file uses that type.
+      const plans = (await sdk.platform.addOn.listPlans(addOn.addon_service.id)) as unknown as Plan[];
       const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
       const items: vscode.QuickPickItem[] = [];
       let lastPlanPrefix = '';

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
@@ -69,12 +69,8 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
     }
     const thenable = (async (): Promise<vscode.QuickPickItem[]> => {
       const sdk = await createHerokuSDK(undefined, undefined, ['addOnExtensions']);
-      // The SDK's listPlans extension returns plans sorted by price
-      // ascending. The downstream code below regroups them by human_name
-      // prefix; the price-sort within each group is the same as before.
       // Cast to schema Plan since the rest of this file uses that type.
-      const plans = (await sdk.platform.addOn.listPlans(addOn.addon_service.id)) as unknown as Plan[];
-      const currencyFormatter = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' });
+      const plans = (await sdk.platform.addOn.listPlansForAddon(addOn.id)) as unknown as Plan[];
       const items: vscode.QuickPickItem[] = [];
       let lastPlanPrefix = '';
 
@@ -89,10 +85,9 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
           });
         }
         lastPlanPrefix = planPrefix;
-        const perMonthMax = currencyFormatter.format(plan.price.cents / 100);
-        const perHourCost = currencyFormatter.format(plan.price.cents / 100 / (24 * 30));
+        const priceSuffix = sdk.platform.addOn.formatPlanPriceLabel(plan as never);
         items.push({
-          label: `${plan.human_name} - ${perHourCost} / hour (Max ${perMonthMax}/month)`,
+          label: priceSuffix ? `${plan.human_name} - ${priceSuffix}` : plan.human_name,
           description: plan.description,
           value: plan.name,
           picked: plan.id === addOn.plan.id

--- a/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
+++ b/src/extension/commands/heroku-cli/heroku-addon-command-runner.ts
@@ -85,7 +85,14 @@ export class HerokuAddOnCommandRunner extends HerokuContextMenuCommandRunner {
           });
         }
         lastPlanPrefix = planPrefix;
-        const priceSuffix = platform.addOn.formatPlanPriceLabel(plan as never);
+        // Schema's `Plan.compliance` and SDK's are not assignable in
+        // either direction (slightly different union shapes), even
+        // though every real payload satisfies both. Cast to the
+        // exact parameter type rather than the bag-of-anything
+        // `as never` so the bypass is documented.
+        const priceSuffix = platform.addOn.formatPlanPriceLabel(
+          plan as Parameters<typeof platform.addOn.formatPlanPriceLabel>[0]
+        );
         items.push({
           label: priceSuffix ? `${plan.human_name} - ${priceSuffix}` : plan.human_name,
           description: plan.description,

--- a/src/extension/utils/heroku-sdk.spec.ts
+++ b/src/extension/utils/heroku-sdk.spec.ts
@@ -1,0 +1,36 @@
+/**
+ * Type-only tests for `createHerokuSDK`'s `extensionNames` parameter.
+ *
+ * These tests don't execute — they exist so TypeScript will refuse to
+ * compile if the generic-over-extension-names inference breaks. The
+ * runtime call is gated behind `if (false)` so the spec runner doesn't
+ * try to actually instantiate an SDK (which would require live auth /
+ * the real ESM dynamic-import path).
+ */
+import { createHerokuSDK } from './heroku-sdk';
+
+void (async () => {
+  if (Math.random() < 0) {
+    // No extensions: the returned SDK has the bare platform/data shape.
+    const bare = await createHerokuSDK();
+    void bare.platform.app.list();
+    void bare.platform.app.info('my-app');
+    // @ts-expect-error  bare SDK has no addOn extension methods
+    void bare.platform.addOn.listPlansForAddon;
+
+    // With addOnExtensions: extension methods become callable on the
+    // matching namespace.
+    const withAddOn = await createHerokuSDK(undefined, undefined, ['addOnExtensions']);
+    void withAddOn.platform.addOn.listPlansForAddon('addon-id');
+    void withAddOn.platform.addOn.formatPlanPriceLabel({} as never);
+    void withAddOn.platform.addOn.upgrade('addon-id', 'plan');
+
+    // @ts-expect-error  unknown extension name is rejected
+    void createHerokuSDK(undefined, undefined, ['notARealExtension']);
+
+    // @ts-expect-error  passing a non-extension utility function name
+    // is rejected — the PlatformExtensionName filter excludes pure
+    // exports like priceForPlan and formatPlanPriceLabel.
+    void createHerokuSDK(undefined, undefined, ['priceForPlan']);
+  }
+})();

--- a/src/extension/utils/heroku-sdk.ts
+++ b/src/extension/utils/heroku-sdk.ts
@@ -1,5 +1,8 @@
 import type { HerokuSDK } from '@heroku/sdk';
+import type * as PlatformExtensions from '@heroku/sdk/extensions/platform';
 import vscode from 'vscode';
+
+type PlatformExtensionName = keyof typeof PlatformExtensions;
 
 const extension = vscode.extensions.getExtension('Heroku-Dev-Tools.heroku') ?? { packageJSON: {} };
 const version = (Reflect.get(extension.packageJSON, 'version') as string) ?? '';
@@ -35,17 +38,35 @@ const TELEMETRY_HEADERS = {
  * @param signal Optional AbortSignal threaded into every route call.
  * @param token Optional explicit bearer token; falls back to the
  *   active VS Code authentication session when omitted.
+ * @param extensionNames Optional names of platform extensions to
+ *   register on the SDK (e.g. `'addOnExtensions'`). The helper
+ *   resolves them via dynamic import so consumers don't need to add
+ *   their own ESM-from-CJS workaround. Methods from registered
+ *   extensions become callable on the matching namespace, e.g.
+ *   `sdk.platform.addOn.listPlans(...)`.
  * @returns An SDK exposing `platform` and `data` namespaces.
  * @example
  * ```ts
  * const sdk = await createHerokuSDK(this.signal);
  * const apps = await sdk.platform.app.list();
+ *
+ * // with extensions
+ * const sdkExt = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
+ * const plans = await sdkExt.platform.addOn.listPlans('heroku-redis');
  * ```
  */
-export async function createHerokuSDK(
+export async function createHerokuSDK<const Names extends readonly PlatformExtensionName[] = readonly []>(
   signal?: AbortSignal,
-  token?: string
-): Promise<Pick<HerokuSDK, 'data' | 'platform'>> {
+  token?: string,
+  extensionNames?: Names
+): Promise<
+  Pick<
+    HerokuSDK<{
+      [K in keyof Names]: (typeof PlatformExtensions)[Names[K] & PlatformExtensionName];
+    }>,
+    'data' | 'platform'
+  >
+> {
   const session = token ? undefined : await vscode.authentication.getSession('heroku:auth:login', []);
 
   const headers: Record<string, string> = { ...TELEMETRY_HEADERS };
@@ -62,23 +83,41 @@ export async function createHerokuSDK(
   // compilation.
   // eslint-disable-next-line no-eval
   const { HerokuSDK: HerokuSDKCtor } = (await (0, eval)('import("@heroku/sdk")')) as typeof import('@heroku/sdk');
+
+  let extensions: readonly unknown[] | undefined;
+  if (extensionNames?.length) {
+    // eslint-disable-next-line no-eval
+    const platformExtensions = (await (0, eval)(
+      'import("@heroku/sdk/extensions/platform")'
+    )) as typeof PlatformExtensions;
+    extensions = extensionNames.map((name) => platformExtensions[name]);
+  }
+
   const sdk = new HerokuSDKCtor({
     clientOptions: {
       headers,
       token: resolvedToken
-    }
+    },
+    extensions: extensions as never
   });
 
-  if (!signal) return sdk;
+  type ResolvedSDK = Pick<
+    HerokuSDK<{
+      [K in keyof Names]: (typeof PlatformExtensions)[Names[K] & PlatformExtensionName];
+    }>,
+    'data' | 'platform'
+  >;
+
+  if (!signal) return sdk as never;
 
   return {
-    get data(): HerokuSDK['data'] {
-      return sdk.data.withOptions({ signal }) as HerokuSDK['data'];
+    get data() {
+      return sdk.data.withOptions({ signal });
     },
-    get platform(): HerokuSDK['platform'] {
-      return sdk.platform.withOptions({ signal }) as HerokuSDK['platform'];
+    get platform() {
+      return sdk.platform.withOptions({ signal });
     }
-  };
+  } as ResolvedSDK;
 }
 
 /**

--- a/src/extension/utils/heroku-sdk.ts
+++ b/src/extension/utils/heroku-sdk.ts
@@ -1,8 +1,14 @@
-import type { HerokuSDK } from '@heroku/sdk';
+import type { HerokuSDK, ResourceExtension } from '@heroku/sdk';
 import type * as PlatformExtensions from '@heroku/sdk/extensions/platform';
 import vscode from 'vscode';
 
-type PlatformExtensionName = keyof typeof PlatformExtensions;
+// Filter the platform-extensions barrel to just the ResourceExtension
+// values (excludes pure utility exports like `priceForPlan` and
+// type-only exports). This is what `createHerokuSDK`'s extensionNames
+// param accepts.
+type PlatformExtensionName = {
+  [K in keyof typeof PlatformExtensions]: (typeof PlatformExtensions)[K] extends ResourceExtension ? K : never;
+}[keyof typeof PlatformExtensions];
 
 const extension = vscode.extensions.getExtension('Heroku-Dev-Tools.heroku') ?? { packageJSON: {} };
 const version = (Reflect.get(extension.packageJSON, 'version') as string) ?? '';

--- a/src/webviews/addons-view/index.ts
+++ b/src/webviews/addons-view/index.ts
@@ -205,7 +205,7 @@ export class HerokuAddOnsMarketplace extends FASTElement {
    */
   private onMessage = (
     event: MessageEvent<{
-      type: 'addons' | 'addonPlans' | 'addonCreated' | 'addonCreationFailed';
+      type: 'addons' | 'addonPlans' | 'addonPlansFailed' | 'addonCreated' | 'addonCreationFailed';
       payload: unknown;
       id?: string;
     }>
@@ -217,6 +217,13 @@ export class HerokuAddOnsMarketplace extends FASTElement {
         {
           this.onAddonPlansMessage(event.data as AddonPlansMessage);
         }
+        break;
+
+      case 'addonPlansFailed':
+        // Stop the spinner on the add-on card whose plan list failed,
+        // restore the install button so the user can retry. The
+        // surface mirrors the addonCreationFailed flow.
+        this.onAddonCreationFailedMessage(event.data.id as string);
         break;
 
       case 'addons':


### PR DESCRIPTION
## Summary

Migrates the VS Code extension's `addOn`/`plan` calls (4 sites across 3 files) from `@heroku-cli/schema`'s `AddOnService`/`PlanService` to `@heroku/sdk`'s `platform.addOn`. Also adds a small affordance to `createHerokuSDK` so callers can opt into resource extensions.

| File | Methods migrated |
|---|---|
| `commands/add-on/list-by-app.ts` | `addOn.listByApp` |
| `commands/add-on/show-addons-view.ts` | `addOn.listByApp`, `addOn.listPlans`, `addOn.create`, `addOn.upgrade` |
| `commands/heroku-cli/heroku-addon-command-runner.ts` | `addOn.listPlans` |

`AddOnAttachmentService` is intentionally untouched — out of scope for this WI.

## Behavior changes worth flagging

- **`update` → `upgrade`.** Plan changes go through the SDK's `addOn.upgrade` extension instead of a raw `addOn.update`. `upgrade` resolves the add-on identity first and qualifies the plan name with the addon_service prefix when needed. The webview already passes a fully-qualified plan, so qualification is a no-op here today, but the resolve adds safety against stale add-on IDs.
- **`create` is plain `create`, not `createAndWait`.** Preserves current UX — provisioning happens in the background and the resource explorer eventually picks it up. `createAndWait` is available if/when we want progress notifications.

## `createHerokuSDK` gets an `extensionNames` parameter

The SDK exposes resource extensions (e.g. `addOnExtensions.listPlans`, `addOnExtensions.upgrade`) via a separate `@heroku/sdk/extensions/platform` import. The extension is compiled to CJS but `@heroku/sdk` is ESM-only with top-level await, so a top-level `require` doesn't work — the dynamic-import workaround already in `createHerokuSDK` handles that for the SDK proper.

To avoid making every consumer add their own dynamic-import dance for extensions, `createHerokuSDK` now accepts an optional `extensionNames` array (e.g. `['addOnExtensions']`). It resolves the names internally, registers them on the constructed SDK, and the helper is generic over the names so the returned SDK exposes the extension methods on the matching namespace:

```ts
const sdk = await createHerokuSDK(this.signal, undefined, ['addOnExtensions']);
const plans = await sdk.platform.addOn.listPlans('heroku-redis');
```

The signal-binding wrapper in `createHerokuSDK` is preserved.

## Type migration

Same boundary pattern as the apps-operations PR: files keep their `@heroku-cli/schema` `AddOn`/`Plan` types internally and cast at the SDK boundary. No type ripple beyond the touched files.

## Testing

`heroku-addon-command-runner.spec.ts` swaps the `PlanService.prototype.listByAddOn` stub for a `sinon.stub(herokuSdkUtil, 'createHerokuSDK')` returning a fake SDK with the `listPlans` stub on the `addOn` namespace. Same pattern used in `deploy-to-heroku.spec.ts` and `resource-explorer.spec.ts` from the previous PR.

`104 tests passing.`

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **fix**: Bug fix
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **test**: Add/update/remove tests

## Testing
**Notes**: Verified end-to-end against a real account using `~/workspace/node-workers-example` (or any app with at least one add-on). Replace `<test-app>` accordingly.

**Steps**:
1. `npm run compile && npm run lint && npm test` — expect 104 passing.
2. F5 to launch Extension Host. Open a workspace with a `heroku` git remote pointing at `<test-app>`.
3. Open the Heroku Resource Explorer and expand `<test-app>` → ADD-ONS. Existing add-ons should populate (exercises `listByApp` from `list-by-app.ts`).
4. Click "Search Elements Marketplace" or whatever surface opens the add-ons webview. The webview should populate (exercises `listByApp` from `show-addons-view.ts`).
5. Click an add-on in the webview to view its plans (exercises `listPlans` from `show-addons-view.ts`).
6. Provision a hobby/free-tier add-on (exercises `create`). The resource explorer should reflect it shortly.
7. Change the plan on an existing add-on (exercises `upgrade`). The new plan should reflect in the resource explorer.
8. From the right-click context menu on an add-on, run `addons:upgrade` and verify the plan picker populates (exercises `listPlans` from `heroku-addon-command-runner.ts`).
9. (Optional) Open DevTools → Network and confirm requests carry the SDK's `Authorization: Bearer ...`, `Referer: vscode-heroku-extension/...`, `User-Agent: VSCode-Heroku-Extension/...` headers.

## Screenshots (if applicable)

## Related Issues
GitHub issue:
GUS work item: [W-22265130](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z0XEyYAN/view)