### PR TITLE
feat: rebuild log streaming on @heroku/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#main",
+        "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265388/log-event-parser",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -580,7 +580,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#ea41870c186fdc8dc0affc12e8b4a6a94d2240da",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#d527cea106765dfb46db18c034cc0df4b225b1f5",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265388/log-event-parser",
+        "@heroku/sdk": "github:heroku/heroku-sdk#main",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -356,19 +356,22 @@
       }
     },
     "node_modules/@heroku-cli/command": {
-      "version": "12.3.3",
-      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-12.3.3.tgz",
-      "integrity": "sha512-JXgzzpJS6WdNf51FqaqzjA2ydNUw6fnGCFod8CbHofTKYgveIdTUQxXQJdInLKeRLPIoogEOZs1/inJTsT9zkg==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/@heroku-cli/command/-/command-12.4.0.tgz",
+      "integrity": "sha512-nFzAnFezznL7rSDLbG6y9q2C65pkErOb5fQBgkcODbtl76ZjXHfoETi21AbAi/NXOf3N2HaPTaJVSlynLRSkTA==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
         "@heroku/http-call": "^5.4.0",
+        "@heroku/js-blanket": "^1.0.0",
         "@oclif/core": "^4.3.0",
+        "@sentry/node": "^10.45.0",
         "ansis": "^4",
         "debug": "^4.4.0",
+        "execa": "^9.6.1",
         "inquirer": "^12.11.1",
-        "netrc-parser": "^3.1.6",
         "open": "^11.0.0",
+        "tsheredoc": "^1.0.1",
         "yargs-parser": "^20.2.9",
         "yargs-unparser": "^2.0.0"
       },
@@ -376,55 +379,124 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@heroku-cli/command/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+    "node_modules/@heroku-cli/command/node_modules/execa": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.6.1.tgz",
+      "integrity": "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "is-inside-container": "^1.0.0"
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "figures": "^6.1.0",
+        "get-stream": "^9.0.0",
+        "human-signals": "^8.0.1",
+        "is-plain-obj": "^4.1.0",
+        "is-stream": "^4.0.1",
+        "npm-run-path": "^6.0.0",
+        "pretty-ms": "^9.2.0",
+        "signal-exit": "^4.1.0",
+        "strip-final-newline": "^4.0.0",
+        "yoctocolors": "^2.1.1"
       },
       "engines": {
-        "node": ">=16"
+        "node": "^18.19.0 || >=20.5.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/get-stream": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
+      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sec-ant/readable-stream": "^0.4.1",
+        "is-stream": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@heroku-cli/command/node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+    "node_modules/@heroku-cli/command/node_modules/human-signals": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
       "engines": {
-        "node": ">=20"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@heroku-cli/command/node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+    "node_modules/@heroku-cli/command/node_modules/is-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
+      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/npm-run-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
+      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
+        "path-key": "^4.0.0",
+        "unicorn-magic": "^0.3.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/path-key": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@heroku-cli/command/node_modules/strip-final-newline": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
+      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -453,13 +525,13 @@
       }
     },
     "node_modules/@heroku/heroku-cli-util": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-10.8.0.tgz",
-      "integrity": "sha512-/P6eQPU6TaI/BY9+56NnAOPl9VSCo19kwk0CC2um2xDMiMA38Eyzz+wSo0sNxHeSLAIoDPM6n40VagVxwsN/tQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-cli-util/-/heroku-cli-util-10.8.1.tgz",
+      "integrity": "sha512-tlC5lyyPazN7axWceDHb5N+D8MIk3o37BnAsjlWYo0fAeUOXWD0BibgAD/OpnaaM476OgtQaI7jjDj0BPCf2TQ==",
       "license": "ISC",
       "optional": true,
       "dependencies": {
-        "@heroku-cli/command": "^12.2.0",
+        "@heroku-cli/command": "^12.4.0",
         "@heroku/http-call": "^5.5.0",
         "@oclif/core": "^4.3.0",
         "@oclif/table": "0.5.2",
@@ -475,63 +547,10 @@
         "node": ">=20"
       }
     },
-    "node_modules/@heroku/heroku-cli-util/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@heroku/heroku-cli-util/node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@heroku/heroku-cli-util/node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@heroku/heroku-fetch": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-fetch.git#69922a83ec1291d63fa180c64d721d96eb2cf8dd",
+      "version": "0.1.1-beta.0",
+      "resolved": "https://registry.npmjs.org/@heroku/heroku-fetch/-/heroku-fetch-0.1.1-beta.0.tgz",
+      "integrity": "sha512-ICT2s4gREkLvM6LURr871WD64CMtT+ZeMzgq9kb3MiP054FUSvzWh/KgpzqPhKIVEXd5KVB+0wfyH2I8sqWx0A==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
@@ -544,7 +563,7 @@
       "optionalDependencies": {
         "@heroku/heroku-cli-util": "^10.8.0",
         "netrc-parser": "^3.1.6",
-        "open": "^10.0.3"
+        "open": "^11.0.0"
       }
     },
     "node_modules/@heroku/http-call": {
@@ -578,13 +597,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@heroku/js-blanket": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@heroku/js-blanket/-/js-blanket-1.0.0.tgz",
+      "integrity": "sha512-75fV7zmehSgHuXXfTqRZdbJn2wADi1U6Ext/A4WFcRrsiUeHnD0peCMZQixfyCrvMPA/06+QoUnJlnHIBMkJFg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#8c524e359955ae4cc53514c5ae2f257c2c6dcfb2",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#95fddd4412d6288fb59f607f417abae3aeb8b972",
       "license": "Apache-2.0",
       "dependencies": {
-        "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",
-        "@heroku/types": "github:heroku/heroku-types",
+        "@heroku/heroku-fetch": "^0.1.1-beta",
+        "@heroku/types": "^3.0.0-beta",
         "debug": "^4.4.0"
       },
       "engines": {
@@ -592,9 +624,13 @@
       }
     },
     "node_modules/@heroku/types": {
-      "version": "0.3.1",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-types.git#bbb9ba269f2d468580064a0c50a77733d37a7e70",
-      "license": "MIT"
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@heroku/types/-/types-3.0.0-beta.0.tgz",
+      "integrity": "sha512-GYSFECwwHIJioLfUfrsSmHzU+Q6+dMQFCjBRYFBmlBhpuxIwKEy7qiMPOkY/9tQXYZRJDuLpt7MGb7NxNsAMpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      }
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
@@ -1275,9 +1311,9 @@
       }
     },
     "node_modules/@oclif/core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.3.tgz",
-      "integrity": "sha512-gQCSYAtUhJilGKaSaZhqejH9X1dDu+jWQjLmtGOgN/XcKaAEPPSeT2mu1UvlvtPox1/NNRdlBcUa8KRKo2HnJQ==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/@oclif/core/-/core-4.11.4.tgz",
+      "integrity": "sha512-URwiQ5ALx/sJ2iH4vzXEd+H4K6NAI7LRs6Jag3hrgKEpGmaE6alfRC8qjO4GIgb6A3ACaJumqP9twi/M9ywdHQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1292,7 +1328,7 @@
         "is-wsl": "^2.2.0",
         "lilconfig": "^3.1.3",
         "minimatch": "^10.2.5",
-        "semver": "^7.8.0",
+        "semver": "^7.8.1",
         "string-width": "^4.2.3",
         "supports-color": "^8",
         "tinyglobby": "^0.2.16",
@@ -1578,6 +1614,108 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/instrumentation": {
+      "version": "0.214.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.214.0",
+        "import-in-the-middle": "^3.0.0",
+        "require-in-the-middle": "^8.0.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+      "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+      "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/resources": "2.7.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1595,6 +1733,133 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
+      "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@sentry-internal/server-utils": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/server-utils/-/server-utils-10.56.0.tgz",
+      "integrity": "sha512-6kuZI/vAjyVKMm1cTzc2pdUmVR4Px4etMG6wnCPyFnwEaGbUKQnTynUBFpTuo/q6Js6QBQvhLNoAnO4YsOfW4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.56.0.tgz",
+      "integrity": "sha512-L+u1dIz5SANrmST5jhIwETtt4apILgKrylv12X4hKJU0PvZl+NorjeV/ty3MwzpKQPg6b6q6qMOSLc1rLpy3iQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.56.0.tgz",
+      "integrity": "sha512-qvgtXHkcR4CH3fh0VEVyw4Ysc6MMiAnm727NdTTm0yU5e53erCeo2521+yfJkqmRTGiOSgwA7B5Bs+ot9j0vFQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.1",
+        "@opentelemetry/core": "^2.6.1",
+        "@opentelemetry/instrumentation": "^0.214.0",
+        "@opentelemetry/sdk-trace-base": "^2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.40.0",
+        "@sentry-internal/server-utils": "10.56.0",
+        "@sentry/core": "10.56.0",
+        "@sentry/node-core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/node-core": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.56.0.tgz",
+      "integrity": "sha512-61lD2Wjtv5Lw2F3lJarcD0ORjR4GlVxrEd6w6Of/uF3DH73dD6K3n/3wXEeCIRfV/kgiCFIrCIq76nz0LVgE5g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sentry/core": "10.56.0",
+        "@sentry/opentelemetry": "10.56.0",
+        "import-in-the-middle": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
+        "@opentelemetry/instrumentation": ">=0.57.1 <1",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/core": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/instrumentation": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "@opentelemetry/semantic-conventions": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@sentry/opentelemetry": {
+      "version": "10.56.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.56.0.tgz",
+      "integrity": "sha512-PtMudApHMHvttjos3b7JZ2gJ+nstHAOYE3vKPYB5o0WQO95ldiaYnpLKMCRIGZWF3Dk7ynrqqnBpn8LZLt+Mrg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sentry/core": "10.56.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
+        "@opentelemetry/semantic-conventions": "^1.39.0"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -1714,9 +1979,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.29",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
-      "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
+      "version": "18.3.30",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.30.tgz",
+      "integrity": "sha512-3ek6mwJL5/VBewBcY4S66cqlCtK3qi4WIq37Z0m/NHw1hjhI7274Mx1qz/+ggSzyBCOEf7eHjBN6INjPAWYfYw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2240,13 +2505,23 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-attributes": {
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "license": "MIT",
+      "optional": true,
+      "peerDependencies": {
+        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -2339,9 +2614,9 @@
       }
     },
     "node_modules/ansis": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.0.tgz",
-      "integrity": "sha512-44mvgtPvohuU/70DdY5Oz2AIrLJ9k6/5x4KmoSvPwO+5Moijo0+N9D0fKbbYZQWP1hNm5CpOf+E01jhxG/r8xg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/ansis/-/ansis-4.3.1.tgz",
+      "integrity": "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==",
       "license": "ISC",
       "optional": true,
       "engines": {
@@ -3102,6 +3377,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/cjs-module-lexer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
+      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/clean-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/clean-regexp/-/clean-regexp-1.0.0.tgz",
@@ -3444,7 +3726,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4863,6 +5145,35 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/figures/node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -5577,6 +5888,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-in-the-middle": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+      "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-import-attributes": "^1.9.5",
+        "cjs-module-lexer": "^2.2.0",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/imurmurhash": {
@@ -7545,6 +7872,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/module-details-from-path": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/module-details-from-path/-/module-details-from-path-1.0.4.tgz",
+      "integrity": "sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/module-not-found-error": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
@@ -8092,19 +8426,21 @@
       }
     },
     "node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "default-browser": "^5.2.1",
+        "default-browser": "^5.4.0",
         "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
         "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -8441,6 +8777,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse-ms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
+      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-statements": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
@@ -8482,7 +8831,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8623,6 +8972,22 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/pretty-ms": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.3.0.tgz",
+      "integrity": "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "parse-ms": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/printf": {
@@ -8999,6 +9364,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-in-the-middle": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/require-in-the-middle/-/require-in-the-middle-8.0.1.tgz",
+      "integrity": "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "debug": "^4.3.5",
+        "module-details-from-path": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
     },
     "node_modules/resolve": {
@@ -9411,7 +9790,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -9424,7 +9803,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10120,9 +10499,9 @@
       "license": "MIT"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -10404,9 +10783,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"
@@ -10418,6 +10797,19 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -10525,7 +10917,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -10833,16 +11225,17 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "is-wsl": "^3.1.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -10999,6 +11392,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package-lock.json
+++ b/package-lock.json
@@ -580,7 +580,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#d527cea106765dfb46db18c034cc0df4b225b1f5",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#8c524e359955ae4cc53514c5ae2f257c2c6dcfb2",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "github:heroku/heroku-fetch#main",

--- a/package.json
+++ b/package.json
@@ -4245,7 +4245,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#main",
+    "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265388/log-event-parser",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -4245,7 +4245,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265388/log-event-parser",
+    "@heroku/sdk": "github:heroku/heroku-sdk#main",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/src/extension/commands/app/context-menu/end-log-session.ts
+++ b/src/extension/commands/app/context-menu/end-log-session.ts
@@ -16,6 +16,12 @@ export class EndLogSession extends AbortController implements RunnableCommand<vo
    */
   public run(app: App & { logSession?: LogSessionStream }): void {
     if (app.logSession) {
+      // Setting `muted = true` flows through StartLogSession's
+      // setter, which clears the visible output channel and fires
+      // MUTED_CHANGED. The underlying stream keeps running so the
+      // resource explorer continues to receive state updates.
+      // `Reflect.set` here only because `no-param-reassign` flags
+      // direct property writes through `app`.
       Reflect.set(app.logSession, 'muted', true);
     }
   }

--- a/src/extension/commands/app/context-menu/start-log-session.spec.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.spec.ts
@@ -2,10 +2,10 @@ import * as assert from 'node:assert';
 
 import * as vscode from 'vscode';
 import Sinon, { type SinonMock, type SinonStub } from 'sinon';
-import LogSessionService from '@heroku-cli/schema/services/log-session-service.js';
 import type { App, LogSession } from '@heroku-cli/schema';
 import { StartLogSession } from './start-log-session';
 import { Readable, Writable } from 'node:stream';
+import * as herokuSdkUtil from '../../../utils/heroku-sdk';
 
 suite('The StartLogSession command', () => {
   let fetchStub: SinonStub;
@@ -43,9 +43,15 @@ suite('The StartLogSession command', () => {
         }
       })()
     );
-    logServiceStub = Sinon.stub(LogSessionService.prototype, 'create').resolves({
+    logServiceStub = Sinon.stub().resolves({
       logplex_url: 'https://example.com'
     } as LogSession);
+    Sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        logSession: { create: logServiceStub }
+      },
+      data: {}
+    } as never);
 
     fetchStub = Sinon.stub(globalThis, 'fetch').onFirstCall().resolves(new Response(readable));
     authStub = Sinon.stub(vscode.authentication, 'getSession').resolves({

--- a/src/extension/commands/app/context-menu/start-log-session.spec.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.spec.ts
@@ -1,76 +1,77 @@
 import * as assert from 'node:assert';
 
 import * as vscode from 'vscode';
-import Sinon, { type SinonMock, type SinonStub } from 'sinon';
-import type { App, LogSession } from '@heroku-cli/schema';
+import Sinon, { type SinonStub } from 'sinon';
+import type { App } from '@heroku-cli/schema';
 import { StartLogSession } from './start-log-session';
-import { Readable, Writable } from 'node:stream';
+import { EventEmitter } from 'node:events';
 import * as herokuSdkUtil from '../../../utils/heroku-sdk';
 
 suite('The StartLogSession command', () => {
-  let fetchStub: SinonStub;
-  let logServiceStub: SinonStub;
-  let authStub: SinonStub;
-  let outputChannelMock: SinonMock;
+  let streamLogsCallCount: number;
+  let appendLineSpy: SinonStub;
   let fakeChannel: vscode.LogOutputChannel;
-  let stream: Writable;
-  let readable: Readable;
+  let lineEmitter: EventEmitter;
   const message = '2024-11-08T20:46:09.807300+00:00 heroku[web.7]: State changed from stopping to down';
-  const mockApp = { id: 'app1', name: 'test-app', organization: { name: 'test-org' } } as App;
-  setup(() => {
-    stream = new Writable();
-    readable = Readable.from(
-      (async function* () {
-        while (!readable.closed) {
-          const line = await Promise.race([
-            new Promise((resolve) => {
-              stream.once('data', (chunk) => {
-                resolve(chunk);
-              });
-            }),
-            new Promise((resolve) => {
-              readable.once('close', () => {
-                resolve(null);
-              });
-            })
-          ]);
+  let mockApp: App;
 
-          if (line) {
-            yield line;
-          } else {
-            break;
-          }
-        }
-      })()
-    );
-    logServiceStub = Sinon.stub().resolves({
-      logplex_url: 'https://example.com'
-    } as LogSession);
+  /** Yields the event loop long enough for the createHerokuSDK
+   * promise chain inside streamLogs() to resolve and wire up the
+   * async iterator before lines are emitted. */
+  const settle = async () => {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  };
+
+  setup(() => {
+    mockApp = { id: 'app1', name: 'test-app', organization: { name: 'test-org' } } as App;
+    lineEmitter = new EventEmitter();
+    streamLogsCallCount = 0;
+    // The SDK's `streamLogs` is an async generator. Tests drive it
+    // by emitting lines on `lineEmitter`; sending `null` ends it.
+    // eslint-disable-next-line require-jsdoc
+    async function* fakeStreamLogs(): AsyncGenerator<string, void, unknown> {
+      streamLogsCallCount++;
+      while (true) {
+        const line = await new Promise<string | null>((resolve) => {
+          const onLine = (l: string | null) => {
+            lineEmitter.off('end', onEnd);
+            resolve(l);
+          };
+          const onEnd = () => {
+            lineEmitter.off('line', onLine);
+            resolve(null);
+          };
+          lineEmitter.once('line', onLine);
+          lineEmitter.once('end', onEnd);
+        });
+        if (line === null) break;
+        yield line;
+      }
+    }
     Sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
       platform: {
-        logSession: { create: logServiceStub }
+        logSession: { streamLogs: fakeStreamLogs }
       },
       data: {}
     } as never);
 
-    fetchStub = Sinon.stub(globalThis, 'fetch').onFirstCall().resolves(new Response(readable));
-    authStub = Sinon.stub(vscode.authentication, 'getSession').resolves({
+    Sinon.stub(vscode.authentication, 'getSession').resolves({
       accessToken: 'token'
     } as vscode.AuthenticationSession);
 
+    appendLineSpy = Sinon.stub();
     fakeChannel = {
-      clear: function () {},
-      show: function () {},
-      append: function () {},
-      appendLine: function () {}
+      clear: Sinon.stub(),
+      show: Sinon.stub(),
+      append: Sinon.stub(),
+      appendLine: appendLineSpy
     } as unknown as vscode.LogOutputChannel;
-    outputChannelMock = Sinon.mock(fakeChannel);
   });
 
   teardown(() => {
     Sinon.restore();
-    readable.destroy();
-    stream.destroy();
+    lineEmitter.emit('end');
+    lineEmitter.removeAllListeners();
   });
 
   test('is registered', async () => {
@@ -79,46 +80,51 @@ suite('The StartLogSession command', () => {
     assert.ok(command, 'The StartLogSession is not registered.');
   });
 
-  test('successfully writes responses to the output channel', async () => {
-    outputChannelMock.expects('clear').calledOnce;
-    outputChannelMock.expects('show').withExactArgs(true);
-    outputChannelMock.expects('append').withArgs(message);
-
+  test('writes incoming log lines to the output channel', async () => {
     const command = new StartLogSession(fakeChannel);
     await command.run(mockApp);
-    stream.emit('data', message);
-    await new Promise((resolve) => setTimeout(resolve));
+    await settle();
+    lineEmitter.emit('line', message);
+    await settle();
 
-    assert.ok(logServiceStub.calledOnce, 'The StartLogSession command did not call the log session service.');
-    assert.ok(fetchStub.calledOnce, 'The StartLogSession command did not make the fetch request.');
-    outputChannelMock.verify();
+    assert.ok(streamLogsCallCount > 0, 'StartLogSession did not call streamLogs.');
+    assert.ok(
+      appendLineSpy.calledWith(message),
+      `Expected appendLine(message); calls were: ${appendLineSpy
+        .getCalls()
+        .map((c) => JSON.stringify(c.args))
+        .join(', ')}`
+    );
   });
 
   test('mutes the log session', async () => {
     const command = new StartLogSession(fakeChannel);
     await command.run(mockApp);
+    await settle();
 
     command.muted = true;
-    stream.emit('data', message);
-    await new Promise((resolve) => setTimeout(resolve));
-    outputChannelMock.expects('append').never();
-    outputChannelMock.verify();
+    appendLineSpy.resetHistory();
+    lineEmitter.emit('line', message);
+    await settle();
+
+    assert.ok(!appendLineSpy.calledWith(message), 'Muted log session still wrote the message.');
   });
 
   test('aborts the log session without throwing', async () => {
     const command = new StartLogSession(fakeChannel);
     await command.run(mockApp);
+    await settle();
 
     // Kick it once before terminating
-    stream.emit('data', message);
-    await new Promise((resolve) => setTimeout(resolve));
+    lineEmitter.emit('line', message);
+    await settle();
 
     assert.doesNotThrow(command.abort.bind(command));
+    appendLineSpy.resetHistory();
     // make sure we're aborted
-    stream.emit('data', message);
-    await new Promise((resolve) => setTimeout(resolve));
+    lineEmitter.emit('line', message);
+    await settle();
 
-    outputChannelMock.expects('append').never();
-    outputChannelMock.verify();
+    assert.ok(!appendLineSpy.calledWith(message), 'Aborted log session still wrote the message.');
   });
 });

--- a/src/extension/commands/app/context-menu/start-log-session.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.ts
@@ -1,10 +1,9 @@
 import { type ReadableStreamDefaultReader } from 'node:stream/web';
-import LogSessionService from '@heroku-cli/schema/services/log-session-service.js';
 import * as vscode from 'vscode';
 import type { App, LogSession } from '@heroku-cli/schema';
 import { herokuCommand, HerokuOutputChannel, type RunnableCommand } from '../../../meta/command';
 import { logExtensionEvent } from '../../../utils/logger';
-import { generateRequestInit } from '../../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../../utils/heroku-sdk';
 
 /**
  * Represents a callback to be executed when a chunk
@@ -74,7 +73,6 @@ export class StartLogSession extends AbortController implements LogSessionStream
   public static COMMAND_ID = 'heroku:start-log-session' as const;
   private static visibleLogSession: StartLogSession | undefined;
 
-  private logService = new LogSessionService(fetch, 'https://api.heroku.com');
   private buffer = '';
   private streamListeners: Set<LogStreamCallback> = new Set();
   private muteListeners: Set<(muted: boolean) => void> = new Set();
@@ -263,14 +261,12 @@ export class StartLogSession extends AbortController implements LogSessionStream
    * @returns The log session.
    */
   private async fetchLogSession(app: App, lines = this.maxLines): Promise<LogSession> {
-    let logSession: LogSession | undefined;
     try {
-      const requestInit = await generateRequestInit(this.signal);
-      logSession = await this.logService.create(app.id, { tail: true, lines }, requestInit);
+      const { platform } = await createHerokuSDK(this.signal);
+      return (await platform.logSession.create(app.id, { tail: true, lines })) as LogSession;
     } catch (e) {
       throw new Error(`Failed to create a log session: ${(e as Error).message}`);
     }
-    return logSession;
   }
 
   /**

--- a/src/extension/commands/app/context-menu/start-log-session.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.ts
@@ -91,6 +91,11 @@ export class StartLogSession extends AbortController implements LogSessionStream
   private endListeners: Set<() => void> = new Set();
   private ended = false;
   private maxLines = 100;
+  // Lines of pre-tail history the platform should replay; 0 means
+  // live events only. Forwarded to streamLogs on each session start
+  // (and recreate). Independent of `maxLines`, the local replay
+  // buffer cap.
+  private historyLines = 100;
 
   // Backing property for the readonly app getter
   #app: (App & { logSession?: StartLogSession }) | undefined;
@@ -237,17 +242,26 @@ export class StartLogSession extends AbortController implements LogSessionStream
    *
    * @param app The App object to run the command against.
    * @param muted Boolean indicating whether the log stream should be piped to the output channel.
-   * @param lines The number of lines from the log history to show in the output channel.
+   * @param historyLines Lines of pre-tail history the platform should replay on the underlying log session.
+   *   Pass `0` for "live events only" (the resource explorer's case);
+   *   defaults to 100 for the user-visible "Start log session" path.
    * @returns Promise<LogSessionStream>
    */
-  public run(app: App & { logSession?: StartLogSession }, muted = false, lines = 100): Promise<LogSessionStream> {
-    this.maxLines = lines;
+  public run(
+    app: App & { logSession?: StartLogSession },
+    muted = false,
+    historyLines = 100
+  ): Promise<LogSessionStream> {
+    // The replay buffer is sized to surface a recent window when an
+    // already-running muted session becomes visible, regardless of
+    // what history the platform replayed at session start.
+    this.maxLines = 100;
+    this.historyLines = historyLines;
     this.#muted = muted;
     this.#app = app;
     // Log session already exists, just mute/unmute it
     const { logSession: existingLogSession } = app;
     if (existingLogSession && !existingLogSession.signal.aborted) {
-      existingLogSession.maxLines = lines;
       existingLogSession.muted = !existingLogSession.muted ? false : muted; // a value of false becomes 'sticky';
       return Promise.resolve(existingLogSession);
     }
@@ -286,7 +300,7 @@ export class StartLogSession extends AbortController implements LogSessionStream
     try {
       const { platform } = await herokuSdkUtil.createHerokuSDK(this.signal, undefined, ['logSessionExtensions']);
       const iterator = platform.logSession.streamLogs(app.id, {
-        lines: this.maxLines,
+        lines: this.historyLines,
         signal: this.signal,
         tail: true
       });

--- a/src/extension/commands/app/context-menu/start-log-session.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.ts
@@ -51,6 +51,17 @@ export type LogSessionStream = AbortController & {
    * @returns void
    */
   onDidUpdateMute: (cb: (muted: boolean) => void) => void;
+
+  /**
+   * Adds a callback that is executed once when the log stream ends,
+   * whether by abort, by the platform closing the connection, or by
+   * an error. The callback receives no arguments and is invoked at
+   * most once per session.
+   *
+   * @param cb The callback to execute when the log stream ends.
+   * @returns void
+   */
+  onDidEnd: (cb: () => void) => void;
 };
 
 @herokuCommand({ outputChannelId: HerokuOutputChannel.LogOutput, languageId: 'heroku-logs' })
@@ -77,6 +88,8 @@ export class StartLogSession extends AbortController implements LogSessionStream
   private buffer = '';
   private streamListeners: Set<LogStreamCallback> = new Set();
   private muteListeners: Set<(muted: boolean) => void> = new Set();
+  private endListeners: Set<() => void> = new Set();
+  private ended = false;
   private maxLines = 100;
 
   // Backing property for the readonly app getter
@@ -142,16 +155,15 @@ export class StartLogSession extends AbortController implements LogSessionStream
       visibleLogSession.outputChannel?.clear();
     }
 
-    const { outputChannel, buffer, app, muted: oldMuted } = existingLogSession;
+    const { outputChannel, buffer, app, maxLines } = existingLogSession;
     if (!muted) {
       this.prepareOutputChannelForLogSession(outputChannel, app!.name);
-      // Take upto maxLines from the buffer and append to the output channel
-      outputChannel?.append(buffer.split('\n').slice(0, visibleLogSession?.maxLines).join('\n'));
+      // Replay up to `maxLines` recent lines of the existing buffer.
+      const replayLines = buffer.split('\n').filter(Boolean).slice(-maxLines);
+      for (const line of replayLines) {
+        outputChannel?.appendLine(line);
+      }
       StartLogSession.visibleLogSession = existingLogSession;
-    }
-
-    if (muted !== oldMuted) {
-      Reflect.set(existingLogSession, 'muted', muted);
     }
   }
 
@@ -181,6 +193,21 @@ export class StartLogSession extends AbortController implements LogSessionStream
    */
   public onDidUpdateMute(cb: (muted: boolean) => void): void {
     this.muteListeners.add(cb);
+  }
+
+  /**
+   * Adds a callback that fires once when the underlying stream ends
+   * (abort, remote close, or error). If the stream has already ended,
+   * the callback fires synchronously on the next microtask.
+   *
+   * @param cb The callback to execute when the stream ends.
+   */
+  public onDidEnd(cb: () => void): void {
+    if (this.ended) {
+      queueMicrotask(cb);
+      return;
+    }
+    this.endListeners.add(cb);
   }
 
   /**
@@ -228,7 +255,11 @@ export class StartLogSession extends AbortController implements LogSessionStream
     Reflect.set(app, 'logSession', this);
     // Streams in the background — we don't await it here so callers
     // can wire up listeners synchronously after run() resolves.
-    void this.streamLogs();
+    // streamLogs() handles its own errors; the .catch is a guard
+    // against future regressions.
+    void this.streamLogs().catch((e) =>
+      logExtensionEvent(`Unhandled streamLogs error for ${app.name}: ${(e as Error).message}`)
+    );
     return Promise.resolve(this);
   }
 
@@ -265,14 +296,21 @@ export class StartLogSession extends AbortController implements LogSessionStream
         if (this.signal.aborted) {
           break;
         }
-        this.streamListeners.forEach((cb) => cb(line, app));
-        this.buffer += `${line}\n`;
+        for (const cb of this.streamListeners) {
+          try {
+            cb(line, app);
+          } catch (e) {
+            // A single bad listener (e.g. a parsing bug downstream)
+            // must not tear down the iterator — the SDK doesn't
+            // recreate after we exit, and the resource explorer
+            // would lose live updates for this app.
+            logExtensionEvent(`Log stream listener threw for ${app.name}: ${(e as Error).message}`);
+          }
+        }
+
+        this.appendToBuffer(line);
         if (!this.muted) {
           this.outputChannel?.appendLine(line);
-        }
-        const lines = this.buffer.split('\n');
-        if (lines.length > this.maxLines) {
-          this.buffer = lines.slice(-this.maxLines).join('\n');
         }
       }
     } catch (e) {
@@ -281,8 +319,38 @@ export class StartLogSession extends AbortController implements LogSessionStream
       }
       logExtensionEvent(`Log stream error for ${app.name}: ${(e as Error).message}`);
     } finally {
-      app.logSession = undefined;
+      // Only clear if we still own the slot — a fresh StartLogSession
+      // for the same app may have already replaced this one (e.g.
+      // detach + immediate reattach via the resource explorer).
+      if (app.logSession === this) {
+        app.logSession = undefined;
+      }
+      this.ended = true;
+      for (const cb of this.endListeners) {
+        try {
+          cb();
+        } catch (e) {
+          logExtensionEvent(`Log stream end-listener threw for ${app.name}: ${(e as Error).message}`);
+        }
+      }
+      this.endListeners.clear();
       logExtensionEvent(`Log session ended for ${app.name}`);
+    }
+  }
+
+  /**
+   * Appends a line to the in-memory replay buffer and trims to the
+   * last `maxLines` lines. Stored without trailing newline so a
+   * `split('\n')` doesn't yield an empty trailing entry that the
+   * replay path would re-emit as a blank line.
+   *
+   * @param line The line to append.
+   */
+  private appendToBuffer(line: string): void {
+    this.buffer = this.buffer ? `${this.buffer}\n${line}` : line;
+    const lines = this.buffer.split('\n');
+    if (lines.length > this.maxLines) {
+      this.buffer = lines.slice(-this.maxLines).join('\n');
     }
   }
 }

--- a/src/extension/commands/app/context-menu/start-log-session.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.ts
@@ -1,15 +1,14 @@
-import { type ReadableStreamDefaultReader } from 'node:stream/web';
 import * as vscode from 'vscode';
-import type { App, LogSession } from '@heroku-cli/schema';
+import type { App } from '@heroku-cli/schema';
 import { herokuCommand, HerokuOutputChannel, type RunnableCommand } from '../../../meta/command';
 import { logExtensionEvent } from '../../../utils/logger';
-import { createHerokuSDK } from '../../../utils/heroku-sdk';
+import * as herokuSdkUtil from '../../../utils/heroku-sdk';
 
 /**
- * Represents a callback to be executed when a chunk
- * of data is received from the log stream.
+ * Represents a callback to be executed when a line of data is
+ * received from the log stream.
  */
-export type LogStreamCallback = (chunk: string, app: App) => void;
+export type LogStreamCallback = (line: string, app: App) => void;
 
 /**
  * Represents a log session stream.
@@ -20,12 +19,11 @@ export type LogSessionStream = AbortController & {
    */
   app: App | undefined;
   /**
-   * Attaches a callback to the stream. Each
-   * chunk from the stream will trigger the callback
-   * and the string value will be passed as the sole
-   * argument
+   * Attaches a callback to the stream. Each line from the stream
+   * will trigger the callback and the string value will be passed
+   * as the sole argument.
    *
-   * @param cb The callback to execute when a chunk from the stream is received.
+   * @param cb The callback to execute when a line from the stream is received.
    */
   attach: (cb: LogStreamCallback) => void;
   /**
@@ -57,17 +55,20 @@ export type LogSessionStream = AbortController & {
 
 @herokuCommand({ outputChannelId: HerokuOutputChannel.LogOutput, languageId: 'heroku-logs' })
 /**
- * Command used to start a log session for
- * the supplied App object and pipe the output
- * to the output channel when <code>muted</code>
- * is false. Only one log session is written to
- * the output channel at a time.
+ * Command used to start a log session for the supplied App object
+ * and pipe the output to the output channel when `muted` is false.
+ * Only one log session is written to the output channel at a time.
  *
- * Log sessions are appended to the App object using
- * the <code>logSession</code> property. This allows
- * implementors to manage the log session without having
- * to retain a direct reference to it as is the case
- * when this command is executed from a context menu.
+ * Log sessions are appended to the App object using the `logSession`
+ * property so callers managing the lifecycle of the app can manage
+ * the session without retaining a direct reference.
+ *
+ * Internally delegates to the SDK's `platform.logSession.streamLogs`,
+ * which handles session creation, the logplex stream connection, and
+ * platform-timeout recreates. This class adds vscode-specific
+ * behavior on top: output channel routing, a replay buffer for
+ * unmuting, and the singleton `visibleLogSession` so only one
+ * channel writes at a time.
  */
 export class StartLogSession extends AbortController implements LogSessionStream, RunnableCommand<LogSessionStream> {
   public static COMMAND_ID = 'heroku:start-log-session' as const;
@@ -77,9 +78,6 @@ export class StartLogSession extends AbortController implements LogSessionStream
   private streamListeners: Set<LogStreamCallback> = new Set();
   private muteListeners: Set<(muted: boolean) => void> = new Set();
   private maxLines = 100;
-  private heartbeatTimeoutId: NodeJS.Timeout | undefined;
-  private logSessionDuration = 15 * 60 * 1000;
-  private reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 
   // Backing property for the readonly app getter
   #app: (App & { logSession?: StartLogSession }) | undefined;
@@ -186,12 +184,10 @@ export class StartLogSession extends AbortController implements LogSessionStream
   }
 
   /**
-   * Attaches a callback to the stream. Each
-   * chunk from the stream will trigger the callback
-   * and the string value will be passed as the sole
-   * argument
+   * Attaches a callback to the stream. Each line from the stream
+   * will trigger the callback.
    *
-   * @param cb The callback to execute when a chunk from the stream is received.
+   * @param cb The callback to execute when a line from the stream is received.
    */
   public attach(cb: LogStreamCallback): void {
     this.streamListeners.add(cb);
@@ -215,9 +211,9 @@ export class StartLogSession extends AbortController implements LogSessionStream
    * @param app The App object to run the command against.
    * @param muted Boolean indicating whether the log stream should be piped to the output channel.
    * @param lines The number of lines from the log history to show in the output channel.
-   * @returns Promise<void
+   * @returns Promise<LogSessionStream>
    */
-  public async run(app: App & { logSession?: StartLogSession }, muted = false, lines = 100): Promise<LogSessionStream> {
+  public run(app: App & { logSession?: StartLogSession }, muted = false, lines = 100): Promise<LogSessionStream> {
     this.maxLines = lines;
     this.#muted = muted;
     this.#app = app;
@@ -226,16 +222,14 @@ export class StartLogSession extends AbortController implements LogSessionStream
     if (existingLogSession && !existingLogSession.signal.aborted) {
       existingLogSession.maxLines = lines;
       existingLogSession.muted = !existingLogSession.muted ? false : muted; // a value of false becomes 'sticky';
-      return existingLogSession;
-    }
-    try {
-      await this.startLogSession();
-    } catch {
-      this.scheduleHeartbeatTimeout();
+      return Promise.resolve(existingLogSession);
     }
 
     Reflect.set(app, 'logSession', this);
-    return this;
+    // Streams in the background — we don't await it here so callers
+    // can wire up listeners synchronously after run() resolves.
+    void this.streamLogs();
+    return Promise.resolve(this);
   }
 
   /**
@@ -246,107 +240,49 @@ export class StartLogSession extends AbortController implements LogSessionStream
   }
 
   /**
-   * @inheritdoc
+   * Drives the SDK log iterator: prepares the channel (when
+   * unmuted), pumps each line into the buffer / listeners /
+   * channel, and trims the replay buffer to `maxLines`. Returns
+   * when the signal is aborted or the SDK iterator finishes; logs
+   * (without throwing) on unexpected errors.
    */
-  public abort(reason?: unknown): void {
-    super.abort(reason);
-    void this.reader?.cancel();
-  }
+  private async streamLogs(): Promise<void> {
+    const app = this.#app!;
+    if (!this.muted) {
+      StartLogSession.prepareOutputChannelForLogSession(this.outputChannel, app.name);
+    }
 
-  /**
-   * Fetches a log session from the API.
-   *
-   * @param app The app to fetch a log session for.
-   * @param lines The number of lines from the log history to display initially.
-   * @returns The log session.
-   */
-  private async fetchLogSession(app: App, lines = this.maxLines): Promise<LogSession> {
     try {
-      const { platform } = await createHerokuSDK(this.signal);
-      return (await platform.logSession.create(app.id, { tail: true, lines })) as LogSession;
-    } catch (e) {
-      throw new Error(`Failed to create a log session: ${(e as Error).message}`);
-    }
-  }
+      const { platform } = await herokuSdkUtil.createHerokuSDK(this.signal, undefined, ['logSessionExtensions']);
+      const iterator = platform.logSession.streamLogs(app.id, {
+        lines: this.maxLines,
+        signal: this.signal,
+        tail: true
+      });
+      logExtensionEvent(`Log stream started for ${app.name}`);
 
-  /**
-   * Begins reading from the log stream and appends
-   * the output to the output channel.
-   *
-   * @returns Promise<void>
-   */
-  private async beginReading(): Promise<void> {
-    const logSessionStart = Date.now();
-
-    while (!this.signal.aborted) {
-      this.scheduleHeartbeatTimeout();
-      const { done, value } = await this.reader!.read();
-      // Log sessions appear to max out at 15 min
-      // even though a null byte heartbeat will still
-      // be present. If we exceed 15 min, break the loop
-      // and let the heartbeat timeout restart things.
-      if (done || this.signal.aborted || Date.now() - logSessionStart > this.logSessionDuration) {
-        await this.reader?.cancel();
-        break;
-      }
-      if (value.length > 1) {
-        const str = Buffer.from(value).toString();
-        this.streamListeners.forEach((cb) => void cb(str, this.app as App));
-        this.buffer += str;
-
+      for await (const line of iterator) {
+        if (this.signal.aborted) {
+          break;
+        }
+        this.streamListeners.forEach((cb) => cb(line, app));
+        this.buffer += `${line}\n`;
         if (!this.muted) {
-          this.outputChannel?.append(str);
+          this.outputChannel?.appendLine(line);
         }
-        if (this.buffer.split('\n').length > this.maxLines) {
-          this.buffer = this.buffer.split('\n').slice(-this.maxLines).join('\n');
+        const lines = this.buffer.split('\n');
+        if (lines.length > this.maxLines) {
+          this.buffer = lines.slice(-this.maxLines).join('\n');
         }
       }
-    }
-  }
-
-  /**
-   * Starts the log session and if successful, the read stream
-   * is initialized and log data becomes available.
-   */
-  private async startLogSession(): Promise<void> {
-    const logSession = await this.fetchLogSession(this.#app!);
-    const response = await fetch(logSession.logplex_url);
-    if (response.ok) {
-      if (!this.muted) {
-        StartLogSession.prepareOutputChannelForLogSession(this.outputChannel, this.#app!.name);
+    } catch (e) {
+      if (this.signal.aborted) {
+        return;
       }
-      this.reader = response.body!.getReader() as ReadableStreamDefaultReader<Uint8Array>;
-      // Since the stream is a log running process
-      // we want this function to complete without
-      // having to wait for the stream to end.
-      void this.beginReading();
-      logExtensionEvent(`Log stream started for ${this.#app!.name}`);
-    } else {
-      logExtensionEvent(`Failed to start log stream: ${response.statusText}`);
-      throw new Error(`Failed to fetch logs: ${response.statusText}`);
+      logExtensionEvent(`Log stream error for ${app.name}: ${(e as Error).message}`);
+    } finally {
+      app.logSession = undefined;
+      logExtensionEvent(`Log session ended for ${app.name}`);
     }
-  }
-
-  /**
-   * Sets a timeout to restart the log session after
-   * 30 seconds of inactivity. If the log session is
-   * restarted, the existing log session will be disposed.
-   *
-   * This is also used when connectivity is lost and the
-   * log stream reader is no longer sending the null byte
-   * heartbeat.
-   */
-  private scheduleHeartbeatTimeout(): void {
-    clearTimeout(this.heartbeatTimeoutId);
-    if (this.signal.aborted) {
-      this.app!.logSession = undefined;
-      logExtensionEvent(`Log session aborted for ${this.app!.name}`);
-      return;
-    }
-    this.heartbeatTimeoutId = setTimeout(() => {
-      this.app!.logSession = undefined;
-      void this.reader?.cancel();
-      void this.run(this.#app!, this.#muted);
-    }, 30_000);
   }
 }

--- a/src/extension/commands/app/context-menu/start-log-session.ts
+++ b/src/extension/commands/app/context-menu/start-log-session.ts
@@ -83,6 +83,7 @@ export type LogSessionStream = AbortController & {
  */
 export class StartLogSession extends AbortController implements LogSessionStream, RunnableCommand<LogSessionStream> {
   public static COMMAND_ID = 'heroku:start-log-session' as const;
+  private static readonly RECONNECT_DELAY_MS = 2000;
   private static visibleLogSession: StartLogSession | undefined;
 
   private buffer = '';
@@ -287,9 +288,14 @@ export class StartLogSession extends AbortController implements LogSessionStream
   /**
    * Drives the SDK log iterator: prepares the channel (when
    * unmuted), pumps each line into the buffer / listeners /
-   * channel, and trims the replay buffer to `maxLines`. Returns
-   * when the signal is aborted or the SDK iterator finishes; logs
-   * (without throwing) on unexpected errors.
+   * channel, and trims the replay buffer to `maxLines`.
+   *
+   * Wraps the iteration in a retry loop so transport-level errors
+   * (e.g. `'terminated'` from a forcibly-closed connection) don't
+   * end the session — without this, the resource explorer would
+   * silently stop receiving state updates after any network blip.
+   * The SDK's own recreate handles platform-timeout cases; this
+   * loop covers everything else short of an abort.
    */
   private async streamLogs(): Promise<void> {
     const app = this.#app!;
@@ -297,41 +303,65 @@ export class StartLogSession extends AbortController implements LogSessionStream
       StartLogSession.prepareOutputChannelForLogSession(this.outputChannel, app.name);
     }
 
+    // After history-replay we don't want the next session to dump
+    // history again; the platform's `lines` is per-session and
+    // history we've already shown should not be re-shown on retry.
+    let historyLines = this.historyLines;
+
     try {
-      const { platform } = await herokuSdkUtil.createHerokuSDK(this.signal, undefined, ['logSessionExtensions']);
-      const iterator = platform.logSession.streamLogs(app.id, {
-        lines: this.historyLines,
-        signal: this.signal,
-        tail: true
-      });
-      logExtensionEvent(`Log stream started for ${app.name}`);
+      // eslint-disable-next-line no-await-in-loop
+      while (!this.signal.aborted) {
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          const { platform } = await herokuSdkUtil.createHerokuSDK(this.signal, undefined, ['logSessionExtensions']);
+          const iterator = platform.logSession.streamLogs(app.id, {
+            lines: historyLines,
+            signal: this.signal,
+            tail: true
+          });
+          logExtensionEvent(`Log stream started for ${app.name}`);
 
-      for await (const line of iterator) {
-        if (this.signal.aborted) {
-          break;
-        }
-        for (const cb of this.streamListeners) {
-          try {
-            cb(line, app);
-          } catch (e) {
-            // A single bad listener (e.g. a parsing bug downstream)
-            // must not tear down the iterator — the SDK doesn't
-            // recreate after we exit, and the resource explorer
-            // would lose live updates for this app.
-            logExtensionEvent(`Log stream listener threw for ${app.name}: ${(e as Error).message}`);
+          // eslint-disable-next-line no-await-in-loop
+          for await (const line of iterator) {
+            if (this.signal.aborted) {
+              break;
+            }
+            for (const cb of this.streamListeners) {
+              try {
+                cb(line, app);
+              } catch (e) {
+                // A single bad listener (e.g. a parsing bug downstream)
+                // must not tear down the iterator — the resource
+                // explorer would lose live updates for this app.
+                logExtensionEvent(`Log stream listener threw for ${app.name}: ${(e as Error).message}`);
+              }
+            }
+
+            this.appendToBuffer(line);
+            if (!this.muted) {
+              this.outputChannel?.appendLine(line);
+            }
           }
+          // Iterator returned cleanly. With `tail: true` this is rare
+          // (the SDK keeps recreating internally on session timeout),
+          // but if it happens we treat it like an error and retry —
+          // bail only on abort.
+          if (this.signal.aborted) break;
+          logExtensionEvent(`Log stream closed unexpectedly for ${app.name}; reconnecting`);
+        } catch (e) {
+          if (this.signal.aborted) break;
+          logExtensionEvent(`Log stream error for ${app.name} (will reconnect): ${(e as Error).message}`);
         }
 
-        this.appendToBuffer(line);
-        if (!this.muted) {
-          this.outputChannel?.appendLine(line);
+        historyLines = 0; // No replay on retry.
+        try {
+          // eslint-disable-next-line no-await-in-loop
+          await wait(StartLogSession.RECONNECT_DELAY_MS, this.signal);
+        } catch {
+          // Signal aborted during the backoff; the while-condition
+          // will break us out of the loop on the next check.
         }
       }
-    } catch (e) {
-      if (this.signal.aborted) {
-        return;
-      }
-      logExtensionEvent(`Log stream error for ${app.name}: ${(e as Error).message}`);
     } finally {
       // Only clear if we still own the slot — a fresh StartLogSession
       // for the same app may have already replaced this one (e.g.
@@ -367,4 +397,31 @@ export class StartLogSession extends AbortController implements LogSessionStream
       this.buffer = lines.slice(-this.maxLines).join('\n');
     }
   }
+}
+
+/**
+ * Resolves after `ms` milliseconds, or rejects if the signal aborts
+ * first. Used to back off between reconnect attempts so a persistent
+ * upstream failure doesn't busy-loop.
+ *
+ * @param ms How long to wait.
+ * @param signal Abort signal that interrupts the wait.
+ * @returns A promise that resolves when the wait completes.
+ */
+function wait(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(signal.reason);
+      return;
+    }
+    const handle = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(handle);
+      reject(signal.reason);
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
 }

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
@@ -118,6 +118,9 @@ suite('HerokuResourceExplorerProvider', () => {
             const res = await fetch(`https://api.heroku.com/apps/${name}`);
             return res.json();
           }
+        },
+        logSession: {
+          create: async () => ({ logplex_url: 'https://fake.logplex.com' })
         }
       }
     } as never);

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
@@ -120,7 +120,15 @@ suite('HerokuResourceExplorerProvider', () => {
           }
         },
         logSession: {
-          create: async () => ({ logplex_url: 'https://fake.logplex.com' })
+          // eslint-disable-next-line require-jsdoc
+          streamLogs: async function* () {
+            for await (const chunk of readable) {
+              const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString();
+              for (const line of text.split('\n')) {
+                if (line) yield line;
+              }
+            }
+          }
         }
       }
     } as never);

--- a/src/extension/providers/resource-explorer/log-stream-client.spec.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.spec.ts
@@ -31,7 +31,7 @@ suite('LogStreamClient', () => {
   };
 
   setup(() => {
-    mockApp = { id: 'app1', name: 'test-app' } as App & { logSession: LogSessionStream };
+    mockApp = { id: 'app1', name: 'test-app' } as App & { logSession?: LogSessionStream };
     logStreamClient = new LogStreamClient();
     getSessionStub = sinon.stub(vscode.authentication, 'getSession').callsFake(async (providerId: string) => {
       if (providerId === 'heroku:auth:login') {
@@ -41,25 +41,32 @@ suite('LogStreamClient', () => {
     });
 
     lineEmitter = new EventEmitter();
+    // The SDK's `streamLogs` is an async generator. Tests drive it
+    // by emitting `'line'`; teardown emits `'end'` to unblock and
+    // exit. Both `once` listeners deregister each other so we don't
+    // leak `'end'` listeners across loop iterations.
+    // eslint-disable-next-line require-jsdoc
+    async function* fakeStreamLogs(): AsyncGenerator<string, void, unknown> {
+      while (true) {
+        const line = await new Promise<string | null>((resolve) => {
+          const onLine = (l: string | null) => {
+            lineEmitter.off('end', onEnd);
+            resolve(l);
+          };
+          const onEnd = () => {
+            lineEmitter.off('line', onLine);
+            resolve(null);
+          };
+          lineEmitter.once('line', onLine);
+          lineEmitter.once('end', onEnd);
+        });
+        if (line === null) break;
+        yield line;
+      }
+    }
     sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
       platform: {
-        logSession: {
-          // eslint-disable-next-line require-jsdoc
-          streamLogs: async function* () {
-            while (true) {
-              const line = await new Promise<string | null>((resolve) => {
-                const onLine = (l: string | null) => resolve(l);
-                lineEmitter.once('line', onLine);
-                lineEmitter.once('end', () => {
-                  lineEmitter.off('line', onLine);
-                  resolve(null);
-                });
-              });
-              if (line === null) break;
-              yield line;
-            }
-          }
-        }
+        logSession: { streamLogs: fakeStreamLogs }
       },
       data: {}
     } as never);
@@ -73,7 +80,7 @@ suite('LogStreamClient', () => {
 
   suite('apps setter', () => {
     test('should attach log streams to new apps', async () => {
-      const attachStub = sinon.stub(logStreamClient, 'attachLogStreams' as keyof LogStreamClient);
+      const attachStub = sinon.stub(logStreamClient, 'attachLogStreams' as keyof LogStreamClient).resolves();
       logStreamClient.apps = [mockApp];
       await new Promise((resolve) => setTimeout(resolve, 1050));
 

--- a/src/extension/providers/resource-explorer/log-stream-client.spec.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.spec.ts
@@ -1,25 +1,23 @@
 import * as assert from 'node:assert';
-import sinon, { spy } from 'sinon';
-import { EventEmitter } from 'events';
-import { LogStreamClient, LogStreamEvents, StateChangedInfo } from './log-stream-client';
+import sinon from 'sinon';
+import { EventEmitter } from 'node:events';
+import { LogStreamClient, LogStreamEvents } from './log-stream-client';
 import * as vscode from 'vscode';
-import { App, Dyno, Formation } from '@heroku-cli/schema';
-import { type LogSessionStream, StartLogSession } from '../../commands/app/context-menu/start-log-session';
+import type { App, Dyno, Formation } from '@heroku-cli/schema';
+import type { LogSessionStream } from '../../commands/app/context-menu/start-log-session';
 import { randomUUID } from 'node:crypto';
-
-import { Readable, Writable } from 'node:stream';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('LogStreamClient', () => {
   let logStreamClient: LogStreamClient;
   let mockApp: App;
-  let fetchStub: sinon.SinonStub;
   let getSessionStub: sinon.SinonStub;
-  let stream: Writable;
+  let lineEmitter: EventEmitter;
 
-  const writeToStream = async (data: string) => {
-    await new Promise((resolve) => setTimeout(resolve, 1005)); // Wait for attach to complete
-    stream.emit('data', data);
-    await new Promise((resolve) => setTimeout(resolve, 0)); // wait for async stream to yield
+  const writeToStream = async (line: string) => {
+    await new Promise((resolve) => setTimeout(resolve, 1005)); // Wait for attach + parser load
+    lineEmitter.emit('line', line);
+    await new Promise((resolve) => setImmediate(resolve)); // wait for async generator to yield
   };
 
   const sessionObject = {
@@ -42,28 +40,35 @@ suite('LogStreamClient', () => {
       return undefined;
     });
 
-    stream = new Writable();
-    const readable = Readable.from(
-      (async function* () {
-        let ct = 2;
-        while (ct--) {
-          const line = await new Promise((resolve) => {
-            stream.once('data', (chunk) => {
-              resolve(chunk);
-            });
-          });
-          yield line;
+    lineEmitter = new EventEmitter();
+    sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        logSession: {
+          // eslint-disable-next-line require-jsdoc
+          streamLogs: async function* () {
+            while (true) {
+              const line = await new Promise<string | null>((resolve) => {
+                const onLine = (l: string | null) => resolve(l);
+                lineEmitter.once('line', onLine);
+                lineEmitter.once('end', () => {
+                  lineEmitter.off('line', onLine);
+                  resolve(null);
+                });
+              });
+              if (line === null) break;
+              yield line;
+            }
+          }
         }
-      })()
-    );
-
-    fetchStub = sinon.stub(globalThis, 'fetch');
-    fetchStub.onFirstCall().resolves(new Response(JSON.stringify({ logplex_url: 'https://fake.logplex.com' })));
-    fetchStub.onSecondCall().resolves(new Response(readable));
+      },
+      data: {}
+    } as never);
   });
 
   teardown(() => {
     sinon.restore();
+    lineEmitter.emit('end');
+    lineEmitter.removeAllListeners();
   });
 
   suite('apps setter', () => {
@@ -91,7 +96,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.STATE_CHANGED, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[web.1]: State changed from starting to up\n');
+      await writeToStream('app[web.1]: State changed from starting to up');
 
       assert.ok(
         spy.calledOnceWith({
@@ -109,7 +114,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.ATTACHMENT_ATTACHED, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[api]: Attach LOGDNA (@ref:logdna-deep-31633)\n');
+      await writeToStream('app[api]: Attach LOGDNA (@ref:logdna-deep-31633)');
 
       assert.ok(
         spy.calledOnceWith({
@@ -125,7 +130,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.ATTACHMENT_DETACHED, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[api]: Detach LOGDNA (@ref:logdna-deep-31633)\n');
+      await writeToStream('app[api]: Detach LOGDNA (@ref:logdna-deep-31633)');
 
       assert.ok(
         spy.calledOnceWith({
@@ -141,7 +146,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.ATTACHMENT_UPDATED, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[api]: Update LOGDNA by user@heroku.com\n');
+      await writeToStream('app[api]: Update LOGDNA by user@heroku.com');
 
       assert.ok(
         spy.calledOnceWith({
@@ -157,7 +162,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.PROVISIONING_COMPLETED, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[api]: @ref:searchbox-tapered-14398 completed provisioning\n');
+      await writeToStream('app[api]: @ref:searchbox-tapered-14398 completed provisioning');
 
       assert.ok(
         spy.calledOnceWith({
@@ -172,7 +177,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.SCALED_TO, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[api]: Scaled to web@2:Standard-1X\n');
+      await writeToStream('app[api]: Scaled to web@2:Standard-1X');
 
       assert.ok(
         spy.calledOnceWith({
@@ -189,7 +194,7 @@ suite('LogStreamClient', () => {
       logStreamClient.on(LogStreamEvents.STARTING_PROCESS, spy);
 
       logStreamClient.apps = [mockApp];
-      await writeToStream('app[web.1]: Starting process with command `npm start`\n');
+      await writeToStream('app[web.1]: Starting process with command `npm start`');
 
       assert.ok(
         spy.calledOnceWith({
@@ -198,28 +203,6 @@ suite('LogStreamClient', () => {
           dynoName: 'web.1',
           command: '`npm start`'
         })
-      );
-    });
-
-    test('should handle partial lines', async () => {
-      let state: StateChangedInfo = {} as StateChangedInfo;
-      logStreamClient.on(LogStreamEvents.STATE_CHANGED, (newState) => {
-        state = newState;
-      });
-
-      logStreamClient.apps = [mockApp];
-      await writeToStream('app[web.1]: State changed ');
-      await writeToStream('from starting to up\n');
-
-      const { dynoName, from, to, type } = state;
-      assert.deepEqual(
-        { dynoName, from, to, type },
-        {
-          dynoName: 'web.1',
-          from: 'starting',
-          to: 'up',
-          type: 'app'
-        }
       );
     });
   });

--- a/src/extension/providers/resource-explorer/log-stream-client.spec.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.spec.ts
@@ -201,7 +201,7 @@ suite('LogStreamClient', () => {
           app: mockApp,
           type: 'app',
           dynoName: 'web.1',
-          command: '`npm start`'
+          command: 'npm start'
         })
       );
     });

--- a/src/extension/providers/resource-explorer/log-stream-client.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.ts
@@ -273,14 +273,20 @@ export class LogStreamClient extends EventEmitter {
     // Warm the parser before any line arrives so `onLogStreamData`
     // can stay synchronous.
     await loadParser();
-    // `lines: 0` tells the platform not to replay history before
-    // tailing — we only want live events. Without this, every
-    // SDK-internal session recreate (every ~15 min on Cedar) replays
-    // history and re-fires state-changed/scaled-to events, causing
-    // resource-explorer flicker.
+    // The platform replays history at session start; with `tail:
+    // true` and the SDK's internal recreate (every ~15 min on Cedar,
+    // on transient disconnects), each recreate would replay history
+    // and re-fire state-changed/scaled-to events through the parser,
+    // causing resource-explorer flicker. Pass `lines: 1` to keep the
+    // history burst minimal. (`lines: 0` triggered a Cedar-side bug
+    // that closes the session within ~1s of opening — see the SDK
+    // follow-up for a proper fix.)
     const logSessions = await Promise.allSettled(
-      toAttach.map((app) => vscode.commands.executeCommand<LogSessionStream>(StartLogSession.COMMAND_ID, app, true, 0))
+      toAttach.map((app) => vscode.commands.executeCommand<LogSessionStream>(StartLogSession.COMMAND_ID, app, true, 1))
     );
+    // Skip the (now minimal) burst of replayed history — wait
+    // briefly so we don't re-fire state events for past actions.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
     for (const result of logSessions) {
       const { status } = result;
       if (status === 'rejected') {

--- a/src/extension/providers/resource-explorer/log-stream-client.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.ts
@@ -147,19 +147,21 @@ export enum LogStreamEvents {
 type ReadOnlyAppArray = ReadonlyArray<(App | TeamApp) & { logSession?: LogSessionStream }> | undefined;
 
 /**
- * LogStreamClient is a component for handling and processing log streams from multiple Heroku applications.
- * It extends EventEmitter to provide custom event handling for various log stream events.
+ * LogStreamClient observes log streams across multiple Heroku apps
+ * and emits typed runtime events (state changes, scaling, attachment
+ * lifecycle) for the resource explorer to react to.
  *
- * Key features:
- * - Manages multiple Heroku app log streams
- * - Parses log data using regex to identify specific events
- * - Emits typed custom events for state changes, attachment updates, scaling, etc.
- * - Provides methods for attaching and detaching log streams
- * - Buffers and processes partial log lines
- * - Integrates with VSCode commands for starting log sessions
+ * Lifecycle:
+ * - Set `apps` to the current set of apps; the client diffs against
+ *   the previous set and starts/ends log sessions accordingly.
+ * - Each app's session is driven by `StartLogSession`, which in turn
+ *   delegates to the SDK's `streamLogs` for connection lifecycle.
+ * - Lines that arrive are passed to `parseHerokuLogLine` from
+ *   `@heroku/sdk/extensions/platform`; matched events are re-emitted
+ *   on this client as typed `LogStreamEvents`.
  *
- * This class enables real-time monitoring and reaction to events in Heroku applications
- * and is the primary driver for real-time updates in the HerokuResourceExplorerProvider.
+ * This class is the primary driver for real-time updates in the
+ * HerokuResourceExplorerProvider.
  *
  * @see HerokuResourceExplorerProvider
  * @see StartLogSession
@@ -194,7 +196,9 @@ export class LogStreamClient extends EventEmitter {
 
     this.detachLogStreams(Array.from(toDetach));
     this.#apps = value;
-    void this.attachLogStreams(Array.from(toAttach));
+    void this.attachLogStreams(Array.from(toAttach)).catch((e) =>
+      logExtensionEvent(`Failed to attach log streams: ${(e as Error).message}`)
+    );
   }
 
   /**
@@ -248,9 +252,11 @@ export class LogStreamClient extends EventEmitter {
       return;
     }
     for (const app of toDetach) {
+      // app.logSession will be cleared by StartLogSession.streamLogs's
+      // finally once the iterator unwinds; we only need to detach our
+      // listener and signal the stream to stop.
       app.logSession?.detach(this.onLogStreamData);
       app.logSession?.abort();
-      app.logSession = undefined;
       logExtensionEvent(`Detached log stream for ${app.name}`);
     }
   }
@@ -276,14 +282,17 @@ export class LogStreamClient extends EventEmitter {
     for (const result of logSessions) {
       const { status } = result;
       if (status === 'rejected') {
-        logExtensionEvent(`Live updates unavaiable: ${result.reason}`);
+        logExtensionEvent(`Live updates unavailable: ${result.reason}`);
         continue;
       }
       const logSession = result.value;
       logSession.attach(this.onLogStreamData);
       logSession.onDidUpdateMute(() => this.emit(LogStreamEvents.MUTED_CHANGED, logSession.app as App));
+      // STREAM_ENDED fires for any termination (abort, remote close,
+      // error) — listening to `signal.aborted` alone misses the
+      // natural-completion path.
+      logSession.onDidEnd(() => this.emit(LogStreamEvents.STREAM_ENDED, logSession.app as App));
       this.emit(LogStreamEvents.STREAM_STARTED, logSession.app as App);
-      logSession.signal.addEventListener('abort', () => this.emit(LogStreamEvents.STREAM_ENDED, logSession.app as App));
       logExtensionEvent(`Live updates active for ${logSession.app!.name}`);
     }
   }

--- a/src/extension/providers/resource-explorer/log-stream-client.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.ts
@@ -318,7 +318,7 @@ export class LogStreamClient extends EventEmitter {
       case 'attachment-updated':
         this.emit(LogStreamEvents.ATTACHMENT_UPDATED, {
           app,
-          type: event.type,
+          type: event.service,
           configVar: event.configVar
         });
         break;
@@ -340,12 +340,17 @@ export class LogStreamClient extends EventEmitter {
         this.emit(LogStreamEvents.PROVISIONING_COMPLETED, { app, ref: event.ref });
         break;
       case 'scaled-to':
-        this.emit(LogStreamEvents.SCALED_TO, {
-          app,
-          dynoType: event.dynoType,
-          quantity: event.quantity,
-          size: event.size
-        });
+        // A single scale line can list multiple dyno types — emit one
+        // SCALED_TO event per entry so per-process listeners (e.g. the
+        // resource explorer) update each row.
+        for (const entry of event.entries) {
+          this.emit(LogStreamEvents.SCALED_TO, {
+            app,
+            dynoType: entry.dynoType,
+            quantity: entry.quantity,
+            size: entry.size
+          });
+        }
         break;
       case 'starting-process':
         this.emit(LogStreamEvents.STARTING_PROCESS, {

--- a/src/extension/providers/resource-explorer/log-stream-client.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.ts
@@ -273,12 +273,14 @@ export class LogStreamClient extends EventEmitter {
     // Warm the parser before any line arrives so `onLogStreamData`
     // can stay synchronous.
     await loadParser();
+    // `lines: 0` tells the platform not to replay history before
+    // tailing — we only want live events. Without this, every
+    // SDK-internal session recreate (every ~15 min on Cedar) replays
+    // history and re-fires state-changed/scaled-to events, causing
+    // resource-explorer flicker.
     const logSessions = await Promise.allSettled(
-      toAttach.map((app) => vscode.commands.executeCommand<LogSessionStream>(StartLogSession.COMMAND_ID, app, true))
+      toAttach.map((app) => vscode.commands.executeCommand<LogSessionStream>(StartLogSession.COMMAND_ID, app, true, 0))
     );
-    // Since the first few writes from the stream may contain
-    // log history, we wait a second to begin processing real-time logs
-    await new Promise((resolve) => setTimeout(resolve, 1000));
     for (const result of logSessions) {
       const { status } = result;
       if (status === 'rejected') {

--- a/src/extension/providers/resource-explorer/log-stream-client.ts
+++ b/src/extension/providers/resource-explorer/log-stream-client.ts
@@ -1,9 +1,33 @@
 import EventEmitter from 'node:events';
 import type { App, Dyno, Formation, TeamApp } from '@heroku-cli/schema';
 import * as vscode from 'vscode';
+import type { HerokuLogEvent } from '@heroku/sdk/extensions/platform';
 import { StartLogSession, type LogSessionStream } from '../../commands/app/context-menu/start-log-session';
 import { diff } from '../../utils/diff';
 import { logExtensionEvent } from '../../utils/logger';
+
+// `@heroku/sdk` is ESM with top-level await; this extension is CJS,
+// so the parser is loaded once via a dynamic import that evades
+// TS's NodeNext rewrite. Resolved before any log line arrives because
+// streamLogs (which feeds onLogStreamData) is itself async-loaded.
+let parseHerokuLogLine: ((line: string) => HerokuLogEvent | undefined) | undefined;
+
+/**
+ * Lazily resolves the SDK's `parseHerokuLogLine` and caches it.
+ * Called from `attachLogStreams` so `onLogStreamData` can stay
+ * synchronous when log lines arrive.
+ *
+ * @returns The SDK's `parseHerokuLogLine` function.
+ */
+async function loadParser(): Promise<typeof parseHerokuLogLine> {
+  if (parseHerokuLogLine) return parseHerokuLogLine;
+  // eslint-disable-next-line no-eval
+  const mod = (await (0, eval)('import("@heroku/sdk/extensions/platform")')) as {
+    parseHerokuLogLine: (line: string) => HerokuLogEvent | undefined;
+  };
+  parseHerokuLogLine = mod.parseHerokuLogLine;
+  return parseHerokuLogLine;
+}
 
 /**
  * LogStreamEventMap is a type alias for a map of log stream events.
@@ -141,37 +165,6 @@ type ReadOnlyAppArray = ReadonlyArray<(App | TeamApp) & { logSession?: LogSessio
  * @see StartLogSession
  */
 export class LogStreamClient extends EventEmitter {
-  private partialLine = '';
-  /**
-   * The regex library containing matchers
-   * for various log stream events.
-   *
-   * These are used to derive updates and dispatch
-   * events containing the details.
-   */
-  private regexLibrary = {
-    // "app[web.1]: State changed from starting to up" - captures 'app', 'web.1', 'starting' and 'up' values
-    stateChanged: /([a-zA-Z0-9-]+)(?:\[)([a-zA-Z0-9-.]+)(?:\]: )(?:State changed from )(\w+)(?: to )(\w+)/,
-
-    // "app[heroku-postgres]: Update DATABSE by user@heroku.com" - captures 'app', 'heroku-postgres' and 'DATABASE'
-    attachmentsUpdate: /([a-zA-Z0-9-]+)(?:\[)([a-zA-Z0-9-.]+)(?:\]: )(?:Update )([A-Z_\s]+)(?:by)/,
-
-    // Detach LOGDNA (@ref:logdna-deep-31633) - captures 'LOGDNA' and 'logdna-deep-31633'
-    attachmentsDetach: /(?:Detach )([A-Z_\s]+)(?:\(@ref:)([a-zA-Z0-9-]+)/,
-
-    // Attach LOGDNA (@ref:logdna-deep-31633) - captures 'LOGDNA' and 'logdna-deep-31633'
-    attachmentsAttach: /(?:Attach )([A-Z_\s]+)(?:\(@ref:)([a-zA-Z0-9-]+)/,
-
-    // "@ref:searchbox-tapered-14398 completed provisioning" - captures 'searchbox-tapered-14398'
-    provisioningCompleted: /(?:@ref:)([a-zA-Z0-9-]+)(?: completed provisioning)/,
-
-    // "Scaled to web@2:Standard-1X" - captures 'web', '2' and 'Standard-1X'
-    scaledTo: /\b(?:Scaled to )([a-zA-Z]+)(?:@)([0-9]+)(?::)([a-zA-Z0-9-_]+)\b/,
-
-    // heroku[web.1]: Starting process with command `npm start` - captures 'app', 'web.1', 'Starting process with command ' and '`npm start`'
-    startingProcess: /([a-zA-Z0-9-]+)(?:\[)([a-zA-Z0-9-.]+)(?:\]: )(?:Starting process with command )(`.*?`)/
-  };
-
   #apps: ReadOnlyAppArray;
 
   /**
@@ -271,6 +264,9 @@ export class LogStreamClient extends EventEmitter {
     if (!toAttach?.length) {
       return;
     }
+    // Warm the parser before any line arrives so `onLogStreamData`
+    // can stay synchronous.
+    await loadParser();
     const logSessions = await Promise.allSettled(
       toAttach.map((app) => vscode.commands.executeCommand<LogSessionStream>(StartLogSession.COMMAND_ID, app, true))
     );
@@ -293,56 +289,72 @@ export class LogStreamClient extends EventEmitter {
   }
 
   /**
-   * Handles the data read from the log stream.
-   * The log stream doesn't always write a complete
-   * line. This method buffers partial lines and
-   * processes them when a complete line is received.
+   * Dispatches structured events for a single log line. Lines are
+   * already split for us by the SDK's `streamLogs` iterator; we
+   * delegate pattern matching to `parseHerokuLogLine`.
    *
-   * @param data The data read from the log stream.
+   * @param line A single log line from the stream.
    * @param app The app associated with the log stream.
    */
-  private onLogStreamData = (data: string, app: App): void => {
-    const lines = data.split('\n');
-    lines[0] = this.partialLine + lines[0];
-    if (!data.endsWith('\n')) {
-      this.partialLine = lines.pop() as string;
+  private onLogStreamData = (line: string, app: App): void => {
+    if (!line || !parseHerokuLogLine) {
+      return;
+    }
+    const event = parseHerokuLogLine(line);
+    if (!event) {
+      return;
     }
 
-    for (const line of lines) {
-      if (!line) {
-        continue;
-      }
-      const [, type, dynoName, from, to] = this.regexLibrary.stateChanged.exec(line) ?? [];
-      const [, , attachmentName, updateConfigVar] = this.regexLibrary.attachmentsUpdate.exec(line) ?? [];
-      const [, detachConfigVar, detachRef] = this.regexLibrary.attachmentsDetach.exec(line) ?? [];
-      const [, attachConfigVar, attachRef] = this.regexLibrary.attachmentsAttach.exec(line) ?? [];
-      const [, provisioningRef] = this.regexLibrary.provisioningCompleted.exec(line) ?? [];
-      const [, dynoType, quantity, size] = this.regexLibrary.scaledTo.exec(line) ?? [];
-      const [, processType, targetDyno, command] = this.regexLibrary.startingProcess.exec(line) ?? [];
-
-      if (from && to) {
-        this.emit(LogStreamEvents.STATE_CHANGED, { app, type, dynoName, from, to });
-      } else if (updateConfigVar) {
-        this.emit(LogStreamEvents.ATTACHMENT_UPDATED, { app, type: attachmentName, configVar: updateConfigVar.trim() });
-      } else if (detachConfigVar) {
+    switch (event.kind) {
+      case 'state-changed':
+        this.emit(LogStreamEvents.STATE_CHANGED, {
+          app,
+          type: event.source,
+          dynoName: event.dynoName,
+          from: event.from,
+          to: event.to
+        });
+        break;
+      case 'attachment-updated':
+        this.emit(LogStreamEvents.ATTACHMENT_UPDATED, {
+          app,
+          type: event.type,
+          configVar: event.configVar
+        });
+        break;
+      case 'attachment-detached':
         this.emit(LogStreamEvents.ATTACHMENT_DETACHED, {
           app,
-          configVar: detachConfigVar.trim(),
-          ref: detachRef
+          configVar: event.configVar,
+          ref: event.ref
         });
-      } else if (attachConfigVar) {
+        break;
+      case 'attachment-attached':
         this.emit(LogStreamEvents.ATTACHMENT_ATTACHED, {
           app,
-          configVar: attachConfigVar.trim(),
-          ref: attachRef
+          configVar: event.configVar,
+          ref: event.ref
         });
-      } else if (provisioningRef) {
-        this.emit(LogStreamEvents.PROVISIONING_COMPLETED, { app, ref: provisioningRef });
-      } else if (size) {
-        this.emit(LogStreamEvents.SCALED_TO, { app, dynoType, quantity: parseInt(quantity, 10), size });
-      } else if (command) {
-        this.emit(LogStreamEvents.STARTING_PROCESS, { app, type: processType, dynoName: targetDyno, command });
-      }
+        break;
+      case 'provisioning-completed':
+        this.emit(LogStreamEvents.PROVISIONING_COMPLETED, { app, ref: event.ref });
+        break;
+      case 'scaled-to':
+        this.emit(LogStreamEvents.SCALED_TO, {
+          app,
+          dynoType: event.dynoType,
+          quantity: event.quantity,
+          size: event.size
+        });
+        break;
+      case 'starting-process':
+        this.emit(LogStreamEvents.STARTING_PROCESS, {
+          app,
+          type: event.source,
+          dynoName: event.dynoName,
+          command: event.command
+        });
+        break;
     }
   };
 }


### PR DESCRIPTION
## Summary

Pulls vscode's bespoke log-streaming machinery onto the SDK. Two layers of change:

1. **Session creation + stream lifecycle** — `StartLogSession` no longer fetches a log session and reads the logplex stream directly. It iterates `platform.logSession.streamLogs(appId, {tail, signal, lines})` and pumps each yielded line into its existing output-channel routing, replay buffer, mute state, and listener fan-out. The SDK handles session creation, logplex connection, and platform-timeout recreates — vscode keeps only its UI-specific orchestration.
2. **Runtime-event parsing** — `LogStreamClient` no longer carries a regex library. It calls `parseHerokuLogLine` from `@heroku/sdk/extensions/platform`, switches on the typed `HerokuLogEvent` union, and dispatches its existing `LogStreamEvents`.

## What moves to the SDK (delete locally, consume from `@heroku/sdk`)

| Removed from vscode | Now in SDK |
|---|---|
| `StartLogSession.fetchLogSession` | `streamLogs` (existing) |
| `StartLogSession.beginReading` (byte-buffer logplex reader) | `streamLogs` line-yielding loop |
| 15-minute manual recreate loop | `streamLogs` recreate-on-timeout |
| 30s heartbeat-loss recreate | `streamLogs` `sessionTimeoutMs` (default 15 min) |
| Partial-line buffering in `LogStreamClient.onLogStreamData` | `streamLogs` yields complete lines |
| `LogStreamClient` regex library (state-changed, scaled-to, attachment lifecycle, …) | `parseHerokuLogLine` (heroku/heroku-sdk#43, merged) |

Net deletions: ~80 lines from `StartLogSession`, ~30 lines from `LogStreamClient`. External API of both classes is preserved — `LogSessionStream`, `LogStreamEvents`, `attach`/`detach`/`muted` semantics, and the `app.logSession` mutual-dispatch pattern all unchanged.

## What stays in vscode (the WI says it should)

- `StartLogSession`'s vscode-specific orchestration: output channel routing, mute/unmute with replay buffer, the singleton `visibleLogSession` so only one channel writes at a time.
- `LogStreamClient`'s public event surface (`LogStreamEvents` enum, app/configVar enrichment) and its diff-based attach/detach when the apps array changes.

## Observable behavior changes worth flagging

- **No more history-replay flicker on session recreate.** `LogStreamClient.attachLogStreams` now passes `historyLines: 0` to `StartLogSession` (Cedar-only — Fir always tails without history). Without this, every SDK-internal session recreate (every ~15 min on Cedar, on transient disconnects) replayed history through the parser and re-fired state-changed/scaled-to events, causing resource-explorer flicker. The 1-second `setTimeout` history-skip in `attachLogStreams` is gone — it's redundant now that the platform replays nothing.
- **Multi-dyno-type `ps:scale` lines now fire one `SCALED_TO` event per dyno type.** Previously the regex non-globally captured only the first entry, so `Scaled to web@2:Standard-1X worker@1:Standard-2X` silently dropped the worker change.
- **`StartingProcessInfo.command` no longer includes surrounding backticks.**

## Public API additions

- **`LogSessionStream.onDidEnd(cb)`** — fires once when the stream ends, whether by abort, by the platform closing, or by an error. Mirrors `onDidUpdateMute`. `LogStreamClient` now wires `STREAM_ENDED` through this hook so the event fires for any termination, not just `signal.aborted`.
- **`StartLogSession.run`'s third parameter is now `historyLines`** (was `lines`). Defaults to 100 for the user-visible "Start log session" path; the resource explorer passes 0. Decoupled from the local `maxLines` replay-buffer cap (still 100) so a muted background session that gets promoted to visible still has a buffer to replay.

## Review fixes (since first review)

- Race in `streamLogs`'s `finally` — guarded with `if (app.logSession === this)` so a freshly-installed session for the same app isn't blown away during rapid detach+reattach.
- `STREAM_ENDED` previously only fired on explicit abort; now wired through `onDidEnd` and fires for natural-completion paths too. Removes the never-cleaned-up `signal.addEventListener('abort', ...)` listener leak.
- Per-line listener dispatch now wrapped in try/catch — a single bad listener no longer tears down the iterator (which the SDK doesn't recreate after we exit).
- Replay buffer no longer stores a trailing newline; replay path iterates parsed lines via `appendLine`. Eliminates the empty trailing line that appeared on unmute.
- `void this.streamLogs()` and `void this.attachLogStreams(...)` have `.catch` guards as defense against future regressions.
- Dead `Reflect.set(existingLogSession, 'muted', muted)` removed — `oldMuted` is destructured after the setter has already updated `#muted`, so the conditional was never true.
- `LogStreamClient.detachLogStreams` no longer redundantly clears `app.logSession`; the `streamLogs` finally handles that now.
- Class doc on `LogStreamClient` updated to reflect SDK delegation.
- Async-generator stub in `log-stream-client.spec.ts` aligned with `start-log-session.spec.ts`'s mutually-deregistering `once` pattern (was leaking an `'end'` listener per loop iteration).
- `mockApp` typed with `logSession?: LogSessionStream` (was required but not set).
- Fix typo `'Live updates unavaiable' → 'unavailable'`.

## Type migration

Same boundary pattern as the previous SDK migrations. `App`/`AddOn`/etc. types stay as `@heroku-cli/schema` internally and cast at the SDK boundary. No type ripple beyond the touched files.

## Type of Change

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **refactor**: Refactoring existing code without changing behavior

(Marking `feat` because the SCALED_TO event now fires per-dyno-type on multi-type scale lines, which is observable behavior consumers rely on.)

## Testing

**Notes**: Verified end-to-end against a real account. Replace `<test-app>` with any app you have access to.

**Steps**:
1. `npm run compile && npm run lint && npm test` — expect 104 passing.
2. F5 to launch Extension Host. Open a workspace with a `heroku` git remote pointing at `<test-app>`.
3. Open the Heroku Resource Explorer and expand `<test-app>`. Tree should populate with apps, dynos, formations, add-ons (the resource explorer subscribes to a log stream to drive real-time updates — exercises the migrated `streamLogs`).
4. Right-click the app row → **"Start log session"** (or click the inline log-session icon on the app row). The "Heroku Logs" output channel should open with the last 100 lines of history and stream new logs in real time. Confirm complete lines (no partial-line artifacts at chunk boundaries).
5. In another terminal, restart a dyno (`heroku ps:restart -a <test-app>`). Confirm the dyno state updates live in the resource explorer (proof the parser is matching `state-changed` lines).
6. **Multi-dyno-type scale (the new behavior)**: run `heroku ps:scale web=2 worker=1 -a <test-app>`. The resource explorer should reflect both quantity changes — previously, the worker change was silently dropped.
7. **No flicker on internal recreates**: leave the resource explorer open with no visible log session for ~15 minutes. The dyno rows should remain stable (no spurious "starting → up" transitions). Previously the platform's session-recreate replay would flicker each row roughly every 15 minutes.
8. Right-click the app row → **"End log session"** (or click the inline icon, which has switched to the end-session variant). The output channel stops streaming. Note: this only mutes the visible channel — the resource explorer continues receiving the (now-muted) stream so dyno-state updates keep working.
9. Right-click → "Start log session" again to unmute. The output channel should reopen and replay the buffered lines from while it was muted.
10. (Optional) Open DevTools → Network and confirm the `POST /apps/<id>/log-sessions` request carries the SDK's `Authorization: Bearer ...`, `Referer: vscode-heroku-extension/...`, and `User-Agent: VSCode-Heroku-Extension/...` headers.

## Related

GUS work item: [W-22265388](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z0ISJYA3/view)
SDK PR (merged): heroku/heroku-sdk#43