### PR TITLE
feat: migrate dyno/formation operations to @heroku/sdk

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#main",
+        "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265258/dyno-info-with-retry",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -612,7 +612,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#95fddd4412d6288fb59f607f417abae3aeb8b972",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#1aa2272e49e8df179ad1222a08e226a98908eed9",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-        "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265258/dyno-info-with-retry",
+        "@heroku/sdk": "github:heroku/heroku-sdk#main",
         "@microsoft/fast-element": "^1.14.0",
         "@vscode/codicons": "^0.0.36",
         "@vscode/l10n": "0.0.x",
@@ -612,7 +612,7 @@
     },
     "node_modules/@heroku/sdk": {
       "version": "0.4.3",
-      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#1aa2272e49e8df179ad1222a08e226a98908eed9",
+      "resolved": "git+ssh://git@github.com/heroku/heroku-sdk.git#655fa8484620b1c4831df6611e1037848fc07bdf",
       "license": "Apache-2.0",
       "dependencies": {
         "@heroku/heroku-fetch": "^0.1.1-beta",

--- a/package.json
+++ b/package.json
@@ -4255,7 +4255,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265258/dyno-info-with-retry",
+    "@heroku/sdk": "github:heroku/heroku-sdk#main",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -4245,7 +4245,7 @@
   },
   "dependencies": {
     "@heroku-cli/schema": "file:heroku-cli-schema-1.0.25.tgz",
-    "@heroku/sdk": "github:heroku/heroku-sdk#main",
+    "@heroku/sdk": "github:heroku/heroku-sdk#eb/W-22265258/dyno-info-with-retry",
     "@microsoft/fast-element": "^1.14.0",
     "@vscode/codicons": "^0.0.36",
     "@vscode/l10n": "0.0.x",

--- a/package.json
+++ b/package.json
@@ -2388,6 +2388,16 @@
           "group": "0000000aaaaa"
         }
       ],
+      "commandPalette": [
+        {
+          "command": "heroku:dyno:restart",
+          "when": "false"
+        },
+        {
+          "command": "heroku:scale-formation",
+          "when": "false"
+        }
+      ],
       "view/item/context": [
         {
           "when": "viewItem =~ /(heroku:dyno):(up|down|crashed)/",

--- a/src/extension/commands/dyno/restart-dyno.ts
+++ b/src/extension/commands/dyno/restart-dyno.ts
@@ -31,13 +31,10 @@ export class RestartDynoCommand extends AbortController implements RunnableComma
     try {
       const { platform } = await createHerokuSDK(this.signal, undefined, ['dynoExtensions']);
       vscode.window.setStatusBarMessage(`${dyno.name} is restarting...`, 4000);
-      // The "skip if already starting" guard the previous
-      // implementation carried was a click-debounce. The resource
-      // explorer's view/item/context already gates the restart
-      // action to viewItem === heroku:dyno:(up|down|crashed), so a
-      // dyno in `starting`/`restarting`/`idle` won't surface the
-      // action at all. Matches the CLI's `heroku ps:restart`
-      // behavior and saves a round-trip.
+      // The resource explorer's view/item/context only shows the
+      // restart action when viewItem === heroku:dyno:(up|down|crashed),
+      // so the platform shouldn't see this on a starting/restarting
+      // dyno from the inline path. Matches `heroku ps:restart`.
       await platform.dyno.restart(dyno.app.id as string, { dyno: dyno.name });
     } catch (e) {
       await vscode.window.showErrorMessage(`Could not restart ${dyno.name}.`);

--- a/src/extension/commands/dyno/restart-dyno.ts
+++ b/src/extension/commands/dyno/restart-dyno.ts
@@ -1,8 +1,7 @@
 import { Dyno } from '@heroku-cli/schema';
-import DynoService from '@heroku-cli/schema/services/dyno-service.js';
 import vscode from 'vscode';
 import { herokuCommand, RunnableCommand } from '../../meta/command';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 
 @herokuCommand()
 /**
@@ -11,7 +10,6 @@ import { generateRequestInit } from '../../utils/generate-service-request-init';
  */
 export class RestartDynoCommand extends AbortController implements RunnableCommand<void> {
   public static COMMAND_ID = 'heroku:dyno:restart' as const;
-  protected dynoService = new DynoService(fetch, 'https://api.heroku.com');
 
   /**
    * Restarts the Dyno after verifying the action
@@ -29,17 +27,18 @@ export class RestartDynoCommand extends AbortController implements RunnableComma
     if (confirmation !== 'Restart') {
       return;
     }
-    const requestInit = await generateRequestInit(this.signal);
 
     try {
-      const { state } = await this.dynoService.info(dyno.app.id as string, dyno.name, requestInit);
-      if (state !== 'starting') {
-        const disposable = vscode.window.setStatusBarMessage(`${dyno.name} is restarting...`);
-        setTimeout(() => {
-          disposable.dispose();
-        }, 4000);
-        await this.dynoService.restart(dyno.app.id as string, dyno.name, requestInit);
-      }
+      const { platform } = await createHerokuSDK(this.signal, undefined, ['dynoExtensions']);
+      vscode.window.setStatusBarMessage(`${dyno.name} is restarting...`, 4000);
+      // The "skip if already starting" guard the previous
+      // implementation carried was a click-debounce. The resource
+      // explorer's view/item/context already gates the restart
+      // action to viewItem === heroku:dyno:(up|down|crashed), so a
+      // dyno in `starting`/`restarting`/`idle` won't surface the
+      // action at all. Matches the CLI's `heroku ps:restart`
+      // behavior and saves a round-trip.
+      await platform.dyno.restart(dyno.app.id as string, { dyno: dyno.name });
     } catch (e) {
       await vscode.window.showErrorMessage(`Could not restart ${dyno.name}.`);
     }

--- a/src/extension/commands/dyno/restart.dyno.spec.ts
+++ b/src/extension/commands/dyno/restart.dyno.spec.ts
@@ -5,13 +5,14 @@ import * as vscode from 'vscode';
 import { randomUUID } from 'node:crypto';
 import { RestartDynoCommand } from './restart-dyno';
 import { Dyno } from '@heroku-cli/schema';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('The RestartDynoCommand', () => {
   let getSessionStub: sinon.SinonStub;
   let showWarningMessageStub: sinon.SinonStub;
   let showErrorMessageStub: sinon.SinonStub;
-  let fetchStub: sinon.SinonStub;
   let setStatusBarMessageStub: sinon.SinonStub;
+  let dynoRestartStub: sinon.SinonStub;
 
   const dyno = {
     name: 'tester-dyno',
@@ -50,16 +51,21 @@ suite('The RestartDynoCommand', () => {
 
     showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage');
 
-    fetchStub = sinon.stub(globalThis, 'fetch');
     setStatusBarMessageStub = sinon.stub(vscode.window, 'setStatusBarMessage');
+
+    dynoRestartStub = sinon.stub();
+    sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        dyno: {
+          restart: dynoRestartStub
+        }
+      },
+      data: {}
+    } as never);
   });
 
   teardown(() => {
-    getSessionStub.restore();
-    showWarningMessageStub.restore();
-    fetchStub.restore();
-    setStatusBarMessageStub.restore();
-    showErrorMessageStub.restore();
+    sinon.restore();
   });
 
   test('is registered', async () => {
@@ -69,26 +75,16 @@ suite('The RestartDynoCommand', () => {
   });
 
   test('restarts the dyno', async () => {
-    fetchStub.onFirstCall().callsFake(async () => {
-      return new Response(JSON.stringify({ id: '1234', state: 'up' } as Dyno));
-    });
-
-    fetchStub.onSecondCall().callsFake(async () => {
-      return new Response(JSON.stringify({ id: '1234', state: 'restarting' } as Dyno));
-    });
+    dynoRestartStub.resolves({ id: '1234', state: 'restarting' } as Dyno);
 
     await vscode.commands.executeCommand<string>(RestartDynoCommand.COMMAND_ID, dyno);
-    assert.ok(!!getSessionStub.exceptions.length);
     assert.ok(setStatusBarMessageStub.calledWith('tester-dyno is restarting...'));
+    assert.ok(dynoRestartStub.calledOnceWith('1234', { dyno: 'tester-dyno' }));
   });
 
   test('shows appropriate status message when restarting fails', async () => {
-    fetchStub.onFirstCall().callsFake(async () => {
-      return new Response(JSON.stringify({ state: 'up' }));
-    });
-    fetchStub.onSecondCall().callsFake(async () => {
-      return new Response(JSON.stringify({}), { status: 401 });
-    });
+    dynoRestartStub.rejects(new Error('Unauthorized'));
+
     await vscode.commands.executeCommand<string>(RestartDynoCommand.COMMAND_ID, dyno);
     assert.ok(showErrorMessageStub.calledWith(`Could not restart ${dyno.name}.`));
   });

--- a/src/extension/commands/dyno/restart.dyno.spec.ts
+++ b/src/extension/commands/dyno/restart.dyno.spec.ts
@@ -2,13 +2,11 @@ import * as assert from 'node:assert';
 import sinon from 'sinon';
 
 import * as vscode from 'vscode';
-import { randomUUID } from 'node:crypto';
 import { RestartDynoCommand } from './restart-dyno';
 import { Dyno } from '@heroku-cli/schema';
 import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('The RestartDynoCommand', () => {
-  let getSessionStub: sinon.SinonStub;
   let showWarningMessageStub: sinon.SinonStub;
   let showErrorMessageStub: sinon.SinonStub;
   let setStatusBarMessageStub: sinon.SinonStub;
@@ -28,24 +26,7 @@ suite('The RestartDynoCommand', () => {
     updated_at: ''
   } as Dyno;
 
-  const sessionObject = {
-    account: {
-      id: 'Heroku',
-      label: 'tester-123@heroku.com'
-    },
-    id: randomUUID(),
-    scopes: [],
-    accessToken: randomUUID()
-  };
-
   setup(() => {
-    getSessionStub = sinon.stub(vscode.authentication, 'getSession').callsFake(async (providerId: string) => {
-      if (providerId === 'heroku:auth:login') {
-        return sessionObject;
-      }
-      return undefined;
-    });
-
     showWarningMessageStub = sinon.stub(vscode.window, 'showWarningMessage');
     showWarningMessageStub.callsFake(async () => 'Restart');
 

--- a/src/extension/commands/dyno/scale-formation.spec.ts
+++ b/src/extension/commands/dyno/scale-formation.spec.ts
@@ -8,8 +8,6 @@ import { ScaleFormationCommand } from './scale-formation';
 import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('The ScaleFormationCommand', () => {
-  let getSessionStub: sinon.SinonStub;
-
   let showErrorMessageStub: sinon.SinonStub;
   let setStatusBarMessageStub: sinon.SinonStub;
   let showInputBoxStub: sinon.SinonStub;
@@ -26,25 +24,8 @@ suite('The ScaleFormationCommand', () => {
     }
   } as Formation;
 
-  const sessionObject = {
-    account: {
-      id: 'Heroku',
-      label: 'tester-123@heroku.com'
-    },
-    id: randomUUID(),
-    scopes: [],
-    accessToken: randomUUID()
-  };
-
   setup(() => {
     showInputBoxStub = sinon.stub(vscode.window, 'showInputBox').callsFake(async () => '5');
-
-    getSessionStub = sinon.stub(vscode.authentication, 'getSession').callsFake(async (providerId: string) => {
-      if (providerId === 'heroku:auth:login') {
-        return sessionObject;
-      }
-      return undefined;
-    });
 
     showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage');
 

--- a/src/extension/commands/dyno/scale-formation.spec.ts
+++ b/src/extension/commands/dyno/scale-formation.spec.ts
@@ -3,23 +3,25 @@ import sinon from 'sinon';
 
 import * as vscode from 'vscode';
 import { randomUUID } from 'node:crypto';
-import { RestartDynoCommand } from './restart-dyno';
-import { Dyno, Formation } from '@heroku-cli/schema';
+import { Formation } from '@heroku-cli/schema';
 import { ScaleFormationCommand } from './scale-formation';
+import * as herokuSdkUtil from '../../utils/heroku-sdk';
 
 suite('The ScaleFormationCommand', () => {
   let getSessionStub: sinon.SinonStub;
 
   let showErrorMessageStub: sinon.SinonStub;
-  let fetchStub: sinon.SinonStub;
   let setStatusBarMessageStub: sinon.SinonStub;
   let showInputBoxStub: sinon.SinonStub;
+  let dynoScaleStub: sinon.SinonStub;
 
   const formation = {
     id: randomUUID(),
     size: 'Standard-X1',
     quantity: 1,
+    type: 'web',
     app: {
+      id: 'app-id',
       name: 'test-app'
     }
   } as Formation;
@@ -46,16 +48,21 @@ suite('The ScaleFormationCommand', () => {
 
     showErrorMessageStub = sinon.stub(vscode.window, 'showErrorMessage');
 
-    fetchStub = sinon.stub(globalThis, 'fetch');
     setStatusBarMessageStub = sinon.stub(vscode.window, 'setStatusBarMessage');
+
+    dynoScaleStub = sinon.stub();
+    sinon.stub(herokuSdkUtil, 'createHerokuSDK').resolves({
+      platform: {
+        dyno: {
+          scale: dynoScaleStub
+        }
+      },
+      data: {}
+    } as never);
   });
 
   teardown(() => {
-    getSessionStub.restore();
-    fetchStub.restore();
-    setStatusBarMessageStub.restore();
-    showErrorMessageStub.restore();
-    showInputBoxStub.restore();
+    sinon.restore();
   });
 
   test('is registered', async () => {
@@ -65,19 +72,19 @@ suite('The ScaleFormationCommand', () => {
   });
 
   test('scales the formation', async () => {
-    fetchStub.onFirstCall().callsFake(async () => {
-      return new Response(JSON.stringify({ id: '1234', quantity: 5 } as Formation));
-    });
+    dynoScaleStub.resolves({ id: '1234', quantity: 5 } as Formation);
 
     await vscode.commands.executeCommand<string>(ScaleFormationCommand.COMMAND_ID, formation);
-    assert.ok(!!getSessionStub.exceptions.length);
     assert.equal(formation.quantity, 5);
+    assert.ok(dynoScaleStub.calledOnce, 'dyno.scale was not called once');
+    const [appId, update] = dynoScaleStub.firstCall.args;
+    assert.equal(appId, formation.app.id);
+    assert.deepEqual(update, { type: formation.type, quantity: 5 });
   });
 
-  test('shows appropriate status message when restarting fails', async () => {
-    fetchStub.onFirstCall().callsFake(async () => {
-      return new Response(JSON.stringify({}), { status: 401 });
-    });
+  test('shows appropriate status message when scaling fails', async () => {
+    dynoScaleStub.rejects(new Error('Unauthorized'));
+
     await vscode.commands.executeCommand<string>(ScaleFormationCommand.COMMAND_ID, formation);
     assert.ok(showErrorMessageStub.calledWith(`Could not scale the formation for the ${formation.app.name} app.`));
   });

--- a/src/extension/commands/dyno/scale-formation.ts
+++ b/src/extension/commands/dyno/scale-formation.ts
@@ -1,8 +1,7 @@
-import FormationService from '@heroku-cli/schema/services/formation-service.js';
 import { Formation } from '@heroku-cli/schema';
 import vscode, { EventEmitter } from 'vscode';
 import { herokuCommand, RunnableCommand } from '../../meta/command';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
+import { createHerokuSDK } from '../../utils/heroku-sdk';
 
 @herokuCommand()
 /**
@@ -11,7 +10,6 @@ import { generateRequestInit } from '../../utils/generate-service-request-init';
 export class ScaleFormationCommand extends AbortController implements RunnableCommand<Promise<void>> {
   public static COMMAND_ID = 'heroku:scale-formation' as const;
 
-  protected formationService = new FormationService(fetch, 'https://api.heroku.com');
   private cancellationToken = new EventEmitter();
 
   /**
@@ -50,15 +48,15 @@ export class ScaleFormationCommand extends AbortController implements RunnableCo
       }
     }
 
-    const requestInit = await generateRequestInit(this.signal);
-
     try {
-      const updatedFormation = await this.formationService.update(
-        formation.app.id as string,
-        formation.id,
-        payload,
-        requestInit
-      );
+      const { platform } = await createHerokuSDK(this.signal, undefined, ['dynoExtensions']);
+      // The resource explorer's existing types are tied to the
+      // legacy @heroku-cli/schema Formation shape; cast at the
+      // boundary so the rest of the file stays unchanged.
+      const updatedFormation = (await platform.dyno.scale(formation.app.id as string, {
+        type: formation.type,
+        quantity: payload.quantity
+      })) as Formation;
       Object.assign(formation, updatedFormation);
     } catch {
       await vscode.window.showErrorMessage(`Could not scale the formation for the ${formation.app.name} app.`);

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.spec.ts
@@ -119,6 +119,29 @@ suite('HerokuResourceExplorerProvider', () => {
             return res.json();
           }
         },
+        dyno: {
+          list: async (appId: string) => {
+            const res = await fetch(`https://api.heroku.com/apps/${appId}/dynos`);
+            return res.json();
+          },
+          info: async (appId: string, dynoIdentity: string) => {
+            const res = await fetch(`https://api.heroku.com/apps/${appId}/dynos/${dynoIdentity}`);
+            return res.json();
+          },
+          // The post-creation 404 race the production code handles
+          // doesn't apply in tests — every fetch stub responds
+          // synchronously — so waitForInfo can just delegate to info.
+          waitForInfo: async (appId: string, dynoIdentity: string) => {
+            const res = await fetch(`https://api.heroku.com/apps/${appId}/dynos/${dynoIdentity}`);
+            return res.json();
+          }
+        },
+        formation: {
+          list: async (appId: string) => {
+            const res = await fetch(`https://api.heroku.com/apps/${appId}/formation`);
+            return res.json();
+          }
+        },
         logSession: {
           // eslint-disable-next-line require-jsdoc
           streamLogs: async function* () {

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
@@ -313,9 +313,9 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
           //
           // Cast to the legacy schema's Dyno; the rest of the file is
           // still tied to that shape.
-          dyno = (await platform.dyno.waitForInfo(app.id, dynoName, { retries: 5 })) as Dyno;
+          dyno = (await platform.dyno.waitForInfo(app.id, dynoName, { attempts: 5 })) as Dyno;
         } catch {
-          // 404 (after retries exhausted), 401, etc.
+          // 404 (after attempts exhausted), 401, etc.
           return;
         }
         // Logs do not stream in order sometimes

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
@@ -1,15 +1,12 @@
 import { EventEmitter } from 'node:events';
 import type { AddOn, App, Dyno, Formation } from '@heroku-cli/schema';
-import DynoService from '@heroku-cli/schema/services/dyno-service.js';
 import vscode, { Uri } from 'vscode';
 
-import FormationService from '@heroku-cli/schema/services/formation-service.js';
 import { diff } from '../../utils/diff';
 import { ListAddOnsByApp } from '../../commands/add-on/list-by-app';
 import type { LogSessionStream } from '../../commands/app/context-menu/start-log-session';
 import { getHerokuAppNames, getRootRepository } from '../../utils/git-utils';
 import { logExtensionEvent } from '../../utils/logger';
-import { generateRequestInit } from '../../utils/generate-service-request-init';
 import { createHerokuSDK } from '../../utils/heroku-sdk';
 import {
   LogStreamClient,
@@ -60,9 +57,6 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
   implements vscode.TreeDataProvider<T>
 {
   public onDidChangeTreeData: vscode.Event<T | T[] | undefined> = this.event;
-
-  protected dynoService = new DynoService(fetch, 'https://api.heroku.com');
-  protected formationService = new FormationService(fetch, 'https://api.heroku.com');
 
   protected apps: Map<App['name'], LogSessionCapableApp> = new Map();
   protected appToResourceMap = new WeakMap<App, AppResources>();
@@ -302,12 +296,8 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
    * Handler for the dyno process starting event.
    *
    * @param data The data dispatched when a dyno is starting
-   * @param retryCount The number of times to retry fetching a dyno from the API before giving up
    */
-  private onDynoProcessStartingOrStateChanged = (
-    data: StartingProcessInfo | StateChangedInfo,
-    retryCount = 5
-  ): void => {
+  private onDynoProcessStartingOrStateChanged = (data: StartingProcessInfo | StateChangedInfo): void => {
     const { app, dynoName } = data;
     const dynos = this.appToResourceMap.get(app)!.dynos;
     let dyno = dynos.find((d) => d.name === dynoName);
@@ -315,14 +305,14 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
     if (!dyno) {
       void (async (): Promise<void> => {
         try {
-          dyno = await this.dynoService.info(app.id, dynoName, await generateRequestInit());
+          const { platform } = await createHerokuSDK(undefined, undefined, ['dynoExtensions']);
+          // The platform briefly returns 404 for a newly-provisioning
+          // dyno even after the "Starting process" log line fires.
+          // waitForInfo polls past the race; with no `states` filter
+          // it returns on first 2xx regardless of state.
+          dyno = (await platform.dyno.waitForInfo(app.id, dynoName, { retries: 5 })) as Dyno;
         } catch {
-          // Dynos that are newly provisioning are 404
-          // for a little while on some formations...not sure why.
-          if (retryCount > 0) {
-            setTimeout(() => void this.onDynoProcessStartingOrStateChanged(data, retryCount - 1), 1000);
-          }
-          // 404, 401
+          // 404 (after retries exhausted), 401, etc.
           return;
         }
         // Logs do not stream in order sometimes
@@ -370,7 +360,8 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
         // Does this dyno need to be removed?
         void (async (): Promise<void> => {
           try {
-            await this.dynoService.info(app.id, dynoName, await generateRequestInit());
+            const { platform } = await createHerokuSDK();
+            await platform.dyno.info(app.id, dynoName);
           } catch {
             // not found - remove it
             const idx = dynos.findIndex((d) => d.name === dynoName);
@@ -458,7 +449,11 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
     if (cachedFormations?.length) {
       return cachedFormations;
     }
-    const formations = await this.formationService.list(app.id, await generateRequestInit());
+    const { platform } = await createHerokuSDK();
+    // The resource explorer's existing types are tied to the
+    // legacy @heroku-cli/schema Formation shape; cast at the
+    // boundary so the rest of the file stays unchanged.
+    const formations = (await platform.formation.list(app.id)) as Formation[];
     formations.forEach((formation) => {
       this.elementTypeMap.set(formation as T, 'Formation');
       this.childParentMap.set(formation as T, parent);
@@ -483,7 +478,11 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
       return cachedDynos;
     }
 
-    const dynos = await this.dynoService.list(app.id, await generateRequestInit());
+    const { platform } = await createHerokuSDK();
+    // The resource explorer's existing types are tied to the
+    // legacy @heroku-cli/schema Dyno shape; cast at the boundary
+    // so the rest of the file stays unchanged.
+    const dynos = (await platform.dyno.list(app.id)) as Dyno[];
     if (!dynos.length) {
       const empty = {
         type: 'empty'

--- a/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
+++ b/src/extension/providers/resource-explorer/heroku-resource-explorer-provider.ts
@@ -310,6 +310,9 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
           // dyno even after the "Starting process" log line fires.
           // waitForInfo polls past the race; with no `states` filter
           // it returns on first 2xx regardless of state.
+          //
+          // Cast to the legacy schema's Dyno; the rest of the file is
+          // still tied to that shape.
           dyno = (await platform.dyno.waitForInfo(app.id, dynoName, { retries: 5 })) as Dyno;
         } catch {
           // 404 (after retries exhausted), 401, etc.
@@ -362,8 +365,13 @@ export class HerokuResourceExplorerProvider<T extends ExtendedTreeDataTypes = Ex
           try {
             const { platform } = await createHerokuSDK();
             await platform.dyno.info(app.id, dynoName);
-          } catch {
-            // not found - remove it
+          } catch (e) {
+            // Only treat 404 as "the dyno is gone"; auth, network,
+            // and rate-limit errors leave the row alone so a transient
+            // failure doesn't cause spurious removals.
+            if ((e as { statusCode?: number })?.statusCode !== 404) {
+              return;
+            }
             const idx = dynos.findIndex((d) => d.name === dynoName);
             if (idx > -1) {
               dynos.splice(idx, 1);


### PR DESCRIPTION
## Summary

Migrates vscode's dyno and formation commands (and one resource-explorer event handler) from the legacy `@heroku-cli/schema` services to the SDK's hand-written `dynoExtensions`. Per the WI:

| Operation | Before | After |
|---|---|---|
| `DynoService.list` | (already migrated to `platform.dyno.list`) | unchanged |
| `FormationService.update` | `platform.formation.update(appId, formationId, {quantity})` | `platform.dyno.scale(appId, {type, quantity})` via `dynoExtensions` |
| `DynoService.restart` | `platform.dyno.info` + state guard + `platform.dyno.restart(appId, name)` | `platform.dyno.restart(appId, {dyno: name})` via `dynoExtensions` |

Plus a new SDK helper that the resource explorer now consumes — see "SDK companion" below.

## Behavior changes worth flagging

- **`restart-dyno`: dropped the inline `state !== 'starting'` guard.** The previous implementation issued `dyno.info` first and skipped the restart if the dyno was in `starting` state. The resource explorer's `view/item/context` menu definition gates the restart action to `viewItem === heroku:dyno:(up|down|crashed)`, so a dyno in `starting`/`restarting`/`idle` doesn't surface the action via the inline path. Now matches the CLI's `heroku ps:restart` (no precondition check, one fewer round-trip).
- **`restart-dyno`: status-bar message now uses vscode's built-in `hideAfterTimeout` overload.** Replaces the manual `setTimeout` + `disposable.dispose()` pair. Same UX, less code.
- **`scale-formation`: switched to `dyno.scale({type, quantity})`** — same wire shape (`formation.update` under the hood) but vocabulary aligned with `heroku ps:scale` and one less type cast at the call site.
- **resource explorer: post-creation 404 race now handled by the SDK.** `onDynoProcessStartingOrStateChanged` previously had a recursive `setTimeout` retry loop (up to 5 attempts at 1s intervals) to handle the platform's brief 404 window for newly-provisioning dynos. That loop is now `await platform.dyno.waitForInfo(app.id, dynoName, {retries: 5})`. Same semantics, lifted out of vscode's state-machine code.
- **resource explorer: narrowed silent dyno removal to 404.** The `down` branch previously treated *any* `dyno.info` failure (including 401, network, rate-limit) as "the dyno is gone" and spliced it out of the local view. Now only 404 triggers the removal; other errors leave the row alone so a transient failure doesn't cause spurious UI churn. Pre-existing latent bug surfaced while reviewing the file.
- **Command Palette gating.** `heroku:dyno:restart` and `heroku:scale-formation` are now hidden from `Cmd+Shift+P` via `menus.commandPalette` `"when": "false"` entries. Both commands require a `Dyno`/`Formation` argument supplied by the resource explorer's `view/item/context` selection — invoked from the palette they got no argument and crashed on `dyno.name`/`formation.quantity`. The resource-explorer entry points (right-click + inline icon) are unchanged.

## SDK companion

Adds `platform.dyno.waitForInfo` — heroku/heroku-sdk#49. Polls `dyno.info` until the dyno exists, optionally until it reaches a caller-specified state. Two distinct races absorbed by one helper:

- **Post-creation 404** (vscode's case): no `states` filter → return on first 2xx regardless of state.
- **Wait for runnable** (CLI's `_ssh` case): `states: ['starting', 'up']` → poll until the dyno reports a runnable state.

`@heroku/sdk` is currently pinned at the feature branch `eb/W-22265258/dyno-info-with-retry` for review — **will repin to `main` before merge**.

## Type of Change

### Feature Additions (minor semver update)
- [x] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [ ] **refactor**: Refactoring existing code without changing behavior

(Marked `feat` because the SDK helper is a new public surface and the dropped state guard / palette gating are observable behavior changes.)

## Testing

**Notes**: All tests pass locally — 104 passing, 0 lint errors. SDK companion has its own unit tests covering the helper.

**Steps**:
1. `npm run compile && npm run lint && npm test` — expect 104 passing.
2. F5 to launch Extension Host. Open a workspace with a `heroku` git remote pointing at a test app.
3. Open the Heroku Resource Explorer. Expand the app → DYNOS. Confirm dynos populate.
4. Right-click a dyno → "Restart". Confirm the status bar shows "<dyno> is restarting..." for ~4 seconds and the dyno transitions through `restarting → starting → up` in the resource explorer.
5. Right-click a formation → "Scale". Enter a new quantity. Confirm the formation count updates.
6. From a terminal, run `heroku ps:scale web=N -a <app>` with N different from the current count. Confirm the resource explorer reflects the change live (this exercises the `waitForInfo` post-creation race when N grows; the new dyno row should appear within a couple seconds even if the platform 404s the first GET).
7. Open the Command Palette (`Cmd+Shift+P`). Type "Heroku: Restart" or "Heroku: Scale" — neither command should appear in the list.

## Related

GUS work item: [W-22265258](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Z0ZdNYAV/view)
SDK PR (dependency): heroku/heroku-sdk#49